### PR TITLE
fix(#19): remove serif font override from .game-instructions

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,7 +54,6 @@ body {
 }
 
 .game-instructions {
-  font-family: 'Forum', Georgia, serif;
   font-size: 1.5rem;
   color: #fff;
   text-align: center;


### PR DESCRIPTION
Closes #19

Removes `font-family: 'Forum', Georgia, serif;` from `.game-instructions` in `style.css` so the subtitle inherits `Inter` from `body`, aligning it with the rest of the UI.

The Forum font import and its usage in `.game-title` and `.site-footer` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)