### PR TITLE
fix(#41): remove phantom space below input area on initial load

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,12 +116,15 @@ function renderFeedback(type, answer, tries) {
     const t = tries === 1 ? "1 try" : `${tries} tries`;
     el.textContent = `You got it in ${t}! The answer was ${answer}.`;
     el.className = "feedback feedback--correct";
+    el.style.display = "";
   } else if (type === "incorrect") {
     el.textContent = "Incorrect — try again.";
     el.className = "feedback feedback--incorrect";
+    el.style.display = "";
   } else {
     el.textContent = "";
     el.className = "feedback";
+    el.style.display = "none";
   }
 }
 
@@ -131,9 +134,11 @@ function renderHistory(guesses) {
   ul.innerHTML = "";
   if (guesses.length === 0) {
     if (label) label.style.display = "none";
+    ul.style.display = "none";
     return;
   }
   if (label) label.style.display = "";
+  ul.style.display = "";
   for (const g of guesses) {
     const li = document.createElement("li");
     li.textContent = g;

--- a/style.css
+++ b/style.css
@@ -192,7 +192,6 @@ body {
 .feedback {
   font-size: 0.95rem;
   font-weight: 500;
-  min-height: 1.4rem;
 }
 
 .feedback--correct {


### PR DESCRIPTION
Closes #41

## Summary
- Remove `min-height: 1.4rem` from `.feedback` CSS rule
- Set `#feedback` to `display:none` in the empty-state branch of `renderFeedback()`
- Set `#history` to `display:none` when `guesses.length === 0` in `renderHistory()`

## Test plan
- [ ] On fresh page load: no visible gap between the clues and the input row
- [ ] After an incorrect guess: `#feedback` and `#history` both appear correctly
- [ ] After a correct guess: `#feedback` shows success message, `#history` shows all previous guesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)