### PR TITLE
feat(#56): Feedback + result flow rewiring

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,47 +157,54 @@ function renderClues(clues) {
 
 // ─── Feedback / history / stats ───────────────────────────────────────────────
 
-function renderFeedback(type, answer, tries) {
-  const el = document.getElementById("feedback");
-  if (!el) return;
+function renderFeedback(type, answer) {
+  const hint = document.getElementById("cw-hint");
+  const fb = document.getElementById("cw-feedback");
   if (type === "correct") {
-    const t = tries === 1 ? "1 try" : `${tries} tries`;
-    el.textContent = `You got it in ${t}! The answer was ${answer}.`;
-    el.className = "feedback feedback--correct";
-    el.style.display = "";
+    if (hint) hint.style.display = "none";
+    if (fb) {
+      fb.textContent = `Congratulations! ${answer} is the correct answer.`;
+      fb.className = "cw-feedback cw-feedback--correct";
+      fb.style.display = "";
+    }
   } else if (type === "incorrect") {
-    el.textContent = "Incorrect — try again.";
-    el.className = "feedback feedback--incorrect";
-    el.style.display = "";
+    if (hint) {
+      hint.textContent = "Incorrect — try again.";
+      hint.style.color = "var(--acc)";
+    }
+    if (fb) fb.style.display = "none";
   } else {
-    el.textContent = "";
-    el.className = "feedback";
-    el.style.display = "none";
+    if (hint) {
+      hint.textContent = "Tap a box to eliminate possible numbers.";
+      hint.style.color = "";
+    }
+    if (fb) {
+      fb.textContent = "";
+      fb.style.display = "none";
+    }
   }
 }
 
 function renderHistory(guesses) {
-  const label = document.getElementById("history-label");
-  const ul = document.getElementById("history");
-  if (!ul) return;
+  const wrap = document.getElementById("cw-history");
+  const ul = document.getElementById("cw-history-list");
+  if (!ul || !wrap) return;
   ul.innerHTML = "";
   if (guesses.length === 0) {
-    if (label) label.style.display = "none";
-    ul.style.display = "none";
+    wrap.style.display = "none";
     return;
   }
-  if (label) label.style.display = "";
-  ul.style.display = "";
+  wrap.style.display = "";
   for (const g of guesses) {
     const li = document.createElement("li");
     li.textContent = g;
-    li.className = "history-item";
+    li.className = "cw-history-item";
     ul.appendChild(li);
   }
 }
 
 function renderStats() {
-  const statsEl = document.getElementById("stats");
+  const statsEl = document.getElementById("cw-stats");
   if (!statsEl) return;
   const history = loadHistory();
   if (history.length === 0) {
@@ -207,13 +214,13 @@ function renderStats() {
   const avg = (history.reduce((s, h) => s + h.tries, 0) / history.length).toFixed(1);
   const last5 = history.slice(0, 5);
   statsEl.innerHTML = `
-    <p class="stats-heading">Your stats</p>
-    <div class="stats-grid">
-      <div class="stats-item"><span class="stats-val">${history.length}</span><span class="stats-lbl">Played</span></div>
-      <div class="stats-item"><span class="stats-val">${avg}</span><span class="stats-lbl">Avg tries</span></div>
+    <p class="cw-stats-heading">Your stats</p>
+    <div class="cw-stats-grid">
+      <div class="cw-stats-item"><span class="cw-stats-val">${history.length}</span><span class="cw-stats-lbl">Played</span></div>
+      <div class="cw-stats-item"><span class="cw-stats-val">${avg}</span><span class="cw-stats-lbl">Avg tries</span></div>
     </div>
-    <p class="stats-last-lbl">Last ${last5.length} game${last5.length !== 1 ? "s" : ""}</p>
-    <div class="stats-bubbles">${last5.map((h) => `<span class="stats-bubble">${h.tries}</span>`).join("")}</div>
+    <p class="cw-stats-last-lbl">Last ${last5.length} game${last5.length !== 1 ? "s" : ""}</p>
+    <div class="cw-stats-bubbles">${last5.map((h) => `<span class="cw-stats-bubble">${h.tries}</span>`).join("")}</div>
   `;
   statsEl.style.display = "";
 }
@@ -327,8 +334,8 @@ function checkSubmit() {
 
 function showNextPuzzle() {
   const num = puzzleNumber(todayLocal());
-  const np = document.getElementById("next-puzzle");
-  const nn = document.getElementById("next-number");
+  const np = document.getElementById("cw-next");
+  const nn = document.getElementById("cw-next-number");
   if (np && nn) {
     nn.textContent = num + 1;
     np.style.display = "";
@@ -337,10 +344,10 @@ function showNextPuzzle() {
 
 function showCompletedState(tries) {
   const t = tries === 1 ? "1 try" : `${tries} tries`;
-  const fb = document.getElementById("feedback");
+  const fb = document.getElementById("cw-feedback");
   if (fb) {
     fb.textContent = `You already solved today's puzzle in ${t}!`;
-    fb.className = "feedback feedback--correct";
+    fb.className = "cw-feedback cw-feedback--correct";
     fb.style.display = "";
   }
   const hintEl = document.getElementById("cw-hint");
@@ -362,14 +369,14 @@ function startRandomPuzzle(puzzleData) {
   renderClues(clues);
 
   gameState = { answer, guesses: [], solved: false, isRandom: true };
-  renderFeedback(null, null, 0);
+  renderFeedback(null);
   renderHistory([]);
 
-  const statsEl = document.getElementById("stats");
+  const statsEl = document.getElementById("cw-stats");
   if (statsEl) statsEl.style.display = "none";
-  const npEl = document.getElementById("next-puzzle");
+  const npEl = document.getElementById("cw-next");
   if (npEl) npEl.style.display = "none";
-  const ragain = document.getElementById("random-again");
+  const ragain = document.getElementById("cw-again");
   if (ragain) ragain.style.display = "none";
   // No score saving for random puzzles
   const saveEl = document.getElementById("cw-save");
@@ -401,12 +408,12 @@ function startDailyPuzzle(puzzleData) {
   }
 
   gameState = { answer, guesses: [], solved: false };
-  renderFeedback(null, null, 0);
+  renderFeedback(null);
   renderHistory([]);
 
-  const statsEl = document.getElementById("stats");
+  const statsEl = document.getElementById("cw-stats");
   if (statsEl) statsEl.style.display = "none";
-  const npEl = document.getElementById("next-puzzle");
+  const npEl = document.getElementById("cw-next");
   if (npEl) npEl.style.display = "none";
 
   const hintEl = document.getElementById("cw-hint");
@@ -436,10 +443,14 @@ function handleGuess() {
 
   if (guess === gameState.answer) {
     gameState.solved = true;
-    renderFeedback("correct", gameState.answer, tries);
+    renderFeedback("correct", gameState.answer);
     closeKeypad();
+    const digitsEl = document.getElementById("cw-digits");
+    if (digitsEl) digitsEl.style.display = "none";
+    const submitWrap = document.getElementById("cw-submit-wrap");
+    if (submitWrap) submitWrap.classList.remove("visible");
     if (gameState.isRandom) {
-      const ragain = document.getElementById("random-again");
+      const ragain = document.getElementById("cw-again");
       if (ragain) ragain.style.display = "";
     } else {
       if (saveScore) {
@@ -450,7 +461,7 @@ function handleGuess() {
     }
   } else {
     gameState.guesses.push(guess);
-    renderFeedback("incorrect", null, 0);
+    renderFeedback("incorrect");
     renderHistory(gameState.guesses);
     // Reset all boxes to full possibles on wrong guess
     possibles = initPossibles();

--- a/index.html
+++ b/index.html
@@ -390,6 +390,28 @@
               cookie
             </label>
           </div>
+
+          <!-- ── Feedback ── -->
+          <p id="cw-feedback" style="display: none"></p>
+
+          <!-- ── Guess history ── -->
+          <div id="cw-history" style="display: none">
+            <p id="cw-history-label">Your guesses</p>
+            <ul id="cw-history-list"></ul>
+          </div>
+
+          <!-- ── Stats ── -->
+          <div id="cw-stats" style="display: none"></div>
+
+          <!-- ── Next puzzle ── -->
+          <p id="cw-next" style="display: none">
+            Puzzle <span id="cw-next-number"></span> is available tomorrow.
+          </p>
+
+          <!-- ── Random again ── -->
+          <p id="cw-again" style="display: none">
+            <a href="/random" id="cw-again-link">Play another random puzzle</a>
+          </p>
         </div>
 
         <div id="cw-foot">

--- a/style.css
+++ b/style.css
@@ -494,6 +494,145 @@ body {
   transition: stroke 0.4s;
 }
 
+/* ─── Feedback ─── */
+#cw-feedback {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.35;
+  margin-top: 1rem;
+  transition: color 0.4s;
+}
+.cw-feedback--correct {
+  color: #4caf88;
+}
+
+/* ─── Guess history ─── */
+#cw-history {
+  margin-top: 0.875rem;
+}
+#cw-history-label {
+  font-family: "Inconsolata", monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+  transition: color 0.4s;
+}
+#cw-history-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+.cw-history-item {
+  font-family: "Inconsolata", monospace;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.125rem;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  background-color: var(--surface);
+  transition:
+    color 0.4s,
+    background-color 0.4s,
+    border-color 0.4s;
+}
+
+/* ─── Stats ─── */
+#cw-stats {
+  margin-top: 1rem;
+}
+.cw-stats-heading {
+  font-family: "Inconsolata", monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+  transition: color 0.4s;
+}
+.cw-stats-grid {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+.cw-stats-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.cw-stats-val {
+  font-family: "Inconsolata", monospace;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+  transition: color 0.4s;
+}
+.cw-stats-lbl {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  transition: color 0.4s;
+}
+.cw-stats-last-lbl {
+  font-size: 0.875rem;
+  color: var(--muted);
+  margin-bottom: 0.375rem;
+  transition: color 0.4s;
+}
+.cw-stats-bubbles {
+  display: flex;
+  gap: 0.375rem;
+}
+.cw-stats-bubble {
+  font-family: "Inconsolata", monospace;
+  font-size: 1rem;
+  font-weight: 600;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  transition:
+    color 0.4s,
+    background-color 0.4s,
+    border-color 0.4s;
+}
+
+/* ─── Next puzzle ─── */
+#cw-next {
+  font-size: 1rem;
+  margin-top: 0.875rem;
+  color: var(--muted);
+  transition: color 0.4s;
+}
+#cw-next-number {
+  font-family: "Inconsolata", monospace;
+  font-weight: 700;
+  color: var(--text);
+  transition: color 0.4s;
+}
+
+/* ─── Random again ─── */
+#cw-again {
+  margin-top: 0.875rem;
+}
+#cw-again-link {
+  color: var(--acc);
+  text-decoration: underline;
+  text-underline-offset: 0.1875rem;
+  font-size: 1rem;
+  transition: color 0.4s;
+}
+
 /* ─── Footer links row ─── */
 #cw-foot-links {
   display: grid;


### PR DESCRIPTION
## Summary
- Adds result-phase DOM elements (`#cw-feedback`, `#cw-history`, `#cw-stats`, `#cw-next`, `#cw-again`) inside `#cw-card`
- Rewires all `app.js` render functions (`renderFeedback`, `renderHistory`, `renderStats`, `showNextPuzzle`, `showCompletedState`, `handleGuess`) to target new `cw-`-prefixed IDs
- Correct-answer text updated to: "Congratulations! {answer} is the correct answer."
- `dlng_history` and `dlng_prefs` localStorage keys/format unchanged

Closes #56

## Test plan
- [ ] Correct guess: `#cw-feedback` shows congratulations in green, digits/submit hidden
- [ ] Incorrect guess: `#cw-hint` shows "Incorrect — try again." in coral, history list updates
- [ ] On solve (daily): stats panel and next-puzzle message appear
- [ ] On solve (random): "Play another random puzzle" link appears, stats hidden
- [ ] Return visit (already solved): completed state renders correctly
- [ ] Light and dark themes render all result elements correctly
- [ ] `dlng_history` entry written with correct tries count
- [ ] Mobile layout (≤480px) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)