### PR TITLE
Mini digit boxes fill tag column width (#125)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -434,7 +434,6 @@
   .clue__digits {
     display: flex;
     justify-content: space-between;
-    inline-size: 4.5rem;
   }
 
   .clue__digit {


### PR DESCRIPTION
Removed fixed width — digits space-between across full subgrid column.