### PR TITLE
Add minimum gap between mini digit indicators (#125)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -434,6 +434,7 @@
   .clue__digits {
     display: flex;
     justify-content: space-between;
+    gap: 2.5px;
   }
 
   .clue__digit {


### PR DESCRIPTION
Prevents mini digit boxes from touching when tag column is narrow.