### PR TITLE
Fix HTP clue tag width (#116)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1221,6 +1221,7 @@
 
   .htp-clue {
     padding: 0;
+    grid-template-columns: max-content 1fr;
   }
 
   .modal-steps {


### PR DESCRIPTION
HTP example clue now uses max-content column sizing instead of inheriting broken subgrid.