### PR TITLE
Add column gap to HTP example clue (#116)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1222,6 +1222,7 @@
   .htp-clue {
     padding: 0;
     grid-template-columns: max-content 1fr;
+    gap: 0 0.8rem;
   }
 
   .modal-steps {


### PR DESCRIPTION
Restores 0.8rem gap between tag and clue text.