### PR TITLE
Sad octopus falls to bottom with physics bounce

### DIFF
--- a/src/octo.ts
+++ b/src/octo.ts
@@ -351,9 +351,9 @@ export function sadOcto(): void {
   const rect = octoWrapEl.getBoundingClientRect();
   const origLeft = rect.left + rect.width / 2;
   const origTop = rect.top;
-  // At 90° rotation (around center), bottom edge = top + height/2 + width/2
-  // We want that flush with viewport bottom, so:
-  const restTop = window.innerHeight - rect.height / 2 - rect.width / 2;
+  // transform-origin is center bottom, so at 90° the lowest point
+  // is at top + height + width/2. We want that flush with viewport bottom.
+  const restTop = window.innerHeight - rect.height - rect.width / 2;
   const fallDist = restTop - rect.top;
 
   octoWrapEl.style.position = 'fixed';


### PR DESCRIPTION
## Summary

On incorrect answer, the octopus falls from header to bottom of viewport with physics-based animation, bounces twice, lies on its side dead for 1s, wakes up (lifts, rotates upright, eyes restore), pauses, then zips back to header.

## Changes

- Physics-based fall using requestAnimationFrame (gravity + damped restitution)
- Rotates to 90° during fall, locks rotation during bounces
- Lands flush at viewport bottom accounting for transform-origin
- Wake sequence: lift 1%, rotate upright, restore face, pause 0.5s, zip up
- Added icon-info and icon-circle-x (hollow) to sprites.svg