### PR TITLE
Bust OG image cache for social platforms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Create work branches off `staging`. Legacy branches (`dev`, `colours`) are being
 
 The Claude Code harness auto-assigns a `claude/*` branch name per session. **Ignore it.** Create `issue/NUM` or `dev/name` off `staging` instead.
 
-After merging, delete remote branches via `gh api -X DELETE "repos/jevawin/clumeral-game/git/refs/heads/BRANCH"` and run `git remote prune origin` to clean up local tracking refs.
+Remote branches are auto-deleted by GitHub on PR merge. After merging, run `git remote prune origin` and delete the local branch to keep things clean.
 
 ### Workflow
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://clumeral.com/" />
     <meta property="og:title" content="Clumeral" />
     <meta property="og:description" content="Work out the number from 100–999. New puzzle every day." />
-    <meta property="og:image" content="https://clumeral.com/og-image.png" />
+    <meta property="og:image" content="https://clumeral.com/og-image.png?v=2" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 


### PR DESCRIPTION
## Summary

Added ?v=2 to og:image URL to force social platforms to re-fetch the updated image. Also updated CLAUDE.md branch cleanup notes.