### PR TITLE
Copyright notice, mean tooltip, min font sizes, feedback tweaks (#87, #142)

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
           <div data-fb-cats role="radiogroup" aria-label="Feedback category">
             <button class="fb-cat active" data-cat="general" role="radio" aria-checked="true">General</button>
             <button class="fb-cat" data-cat="bug" role="radio" aria-checked="false">Bug</button>
-            <button class="fb-cat" data-cat="suggestion" role="radio" aria-checked="false">Suggestion</button>
+            <button class="fb-cat" data-cat="suggestion" role="radio" aria-checked="false">Idea</button>
             <button class="fb-cat" data-cat="praise" role="radio" aria-checked="false">Praise</button>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -466,6 +466,7 @@
             </span>
             and Dave
           </div>
+          <p class="footer__copyright">&copy; 2026 Jamie &amp; Dave</p>
           <div class="dev-links hidden" data-dev-links></div>
         </footer>
       </main>

--- a/src/app.ts
+++ b/src/app.ts
@@ -149,7 +149,7 @@ const TAG_TIPS: Record<string, string> = {
   SUM: "Digits added together",
   DIFF: "Smaller of the digits subtracted from larger",
   PROD: "Digits multiplied together",
-  MEAN: "Sum of, divided by count of digits",
+  MEAN: "Sum of digits divided by how many digits",
   RANGE: "Largest digit minus the smallest",
 };
 

--- a/src/style.css
+++ b/src/style.css
@@ -1539,7 +1539,7 @@
   [data-fb-cats] {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    justify-content: space-between;
     margin-block-end: 0.75rem;
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -404,7 +404,7 @@
   }
 
   .tag-tip__text {
-    font-size: 0.875rem;
+    font-size: 1rem;
     line-height: 1.4;
     color: var(--text);
     white-space: normal;
@@ -421,7 +421,7 @@
     border: none;
     cursor: pointer;
     font-family: "DM Sans", system-ui, sans-serif;
-    font-size: 0.8125rem;
+    font-size: 1rem;
     color: var(--muted);
     padding: 0;
     transition: color 0.2s;
@@ -849,13 +849,13 @@
   }
 
   .stats__lbl {
-    font-size: 0.8125rem;
+    font-size: 1rem;
     color: var(--muted);
     transition: color 0.4s;
   }
 
   .stats__last-lbl {
-    font-size: 0.875rem;
+    font-size: 1rem;
     color: var(--muted);
     margin-block-end: 0.375rem;
     transition: color 0.4s;
@@ -1016,7 +1016,6 @@
 
   .footer__copyright {
     margin: 0;
-    font-size: 0.8125rem;
     color: var(--muted);
     transition: color 0.4s;
   }
@@ -1063,7 +1062,7 @@
   .swatch-btn {
     display: flex;
     align-items: center;
-    gap: 0.3rem;
+    gap: 0.5rem;
     padding: 0.3rem 0.5rem;
     border: 1.5px solid var(--border);
     border-radius: 0.25rem;
@@ -1080,8 +1079,7 @@
   }
 
   .swatch-btn__label {
-    font-weight: 700;
-    font-size: 0.8rem;
+    font-size: 1rem;
   }
 
   /* ─── Dev links ─── */
@@ -1253,7 +1251,7 @@
   }
 
   .modal-footer {
-    font-size: 0.875rem;
+    font-size: 1rem;
     color: var(--muted);
     text-align: center;
     margin-block-start: 0.25rem;
@@ -1322,7 +1320,7 @@
   }
 
   .modal-step-label {
-    font-size: 0.9375rem;
+    font-size: 1rem;
     line-height: 1.4;
     color: var(--text);
     transition: color 0.4s;
@@ -1427,7 +1425,7 @@
     border-block-end: 1px solid var(--muted);
     color: var(--muted);
     font-family: "DM Sans", system-ui, sans-serif;
-    font-size: 0.875rem;
+    font-size: 1rem;
     line-height: 1.4;
     padding: 0;
     cursor: pointer;
@@ -1547,7 +1545,7 @@
 
   .fb-cat {
     font-family: "DM Sans", system-ui, sans-serif;
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 500;
     padding: 0.375rem 0.875rem;
     border-radius: 1rem;
@@ -1600,7 +1598,7 @@
 
   /* ── Character counter ── */
   .fb-counter {
-    font-size: 0.8125rem;
+    font-size: 1rem;
     text-align: end;
     margin-block-start: 0.25rem;
     color: var(--muted);
@@ -1613,7 +1611,7 @@
 
   /* ── Metadata block ── */
   .fb-meta-label {
-    font-size: 0.8125rem;
+    font-size: 1rem;
     color: var(--muted);
     margin-block-start: 0.75rem;
     margin-block-end: 0.375rem;
@@ -1622,7 +1620,7 @@
 
   .fb-meta {
     font-family: "Inconsolata", monospace;
-    font-size: 0.8125rem;
+    font-size: 1rem;
     line-height: 1.6;
     color: var(--muted);
     padding: 0.5rem 0.75rem;
@@ -1686,7 +1684,7 @@
     background-color: var(--text);
     color: var(--bg);
     font-family: "DM Sans", system-ui, sans-serif;
-    font-size: 0.9375rem;
+    font-size: 1rem;
     font-weight: 500;
     box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
     opacity: 0;

--- a/src/style.css
+++ b/src/style.css
@@ -1014,6 +1014,13 @@
     display: block;
   }
 
+  .footer__copyright {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--muted);
+    transition: color 0.4s;
+  }
+
   /* ─── Footer heart ─── */
   @keyframes heart-bounce {
     0% {


### PR DESCRIPTION
## Summary
- Add "© 2026 Jamie & Dave" copyright notice to footer (#87)
- Change mean tooltip to "Sum of digits divided by how many digits" (#142)
- Enforce 1rem (16px) minimum font size across all UI (except decorative HTP keys)
- Colour picker labels: normal weight, wider gap
- Rename feedback category "Suggestion" to "Idea"
- Space feedback pills with space-between

## Test plan
- [ ] Copyright shows below "Made with... by Jamie and Dave", above dev links
- [ ] Both light and dark themes
- [ ] Mean tooltip text reads correctly
- [ ] Font sizes look right across stats, tooltips, feedback, HTP modals
- [ ] Colour picker labels readable
- [ ] Feedback pills spaced evenly

🤖 Generated with [Claude Code](https://claude.com/claude-code)