### PR TITLE
Fix iOS status bar colour matching blob instead of background (#101)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -100,7 +100,7 @@
   /* ─── Background blobs ─── */
   .game__shape {
     position: fixed;
-    inset-block-start: -8.75rem;
+    inset-block-start: 0.25rem;
     inset-inline-end: -7.5rem;
     inline-size: 28.75rem;
     block-size: 28.75rem;
@@ -114,6 +114,8 @@
 
   .game__shape--alt {
     position: fixed;
+    inset-block-start: auto;
+    inset-inline-end: auto;
     inset-block-end: -6.25rem;
     inset-inline-start: -5rem;
     inline-size: 16.25rem;


### PR DESCRIPTION
## Summary
- Move top-right blob down so its top edge clears the viewport, giving iOS a strip of pure background to sample for the status bar
- Fix alt blob (bottom-left) positioning that broke when top value changed — reset inherited inset properties

## Test plan
- [ ] iOS status bar matches background colour, not blob accent
- [ ] Two blobs visible: top-right and bottom-left
- [ ] Blobs shift colour with accent picker
- [ ] Light/dark toggle works
- [ ] No visual regression on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)