### PR TITLE
Show eliminated 0 in hundreds box, unify digit grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,16 +98,16 @@
                 <div class="htp-worked">
                   <div class="digit-box htp-box">
                     <div class="digit-box__grid four-col">
-                      <span class="elim">0</span>
                       <span>1</span>
                       <span>2</span>
                       <span>3</span>
                       <span>4</span>
-                      <span class="digit-box__mid">5</span>
+                      <span>5</span>
                       <span>6</span>
                       <span>7</span>
-                      <span class="digit-box__mid">8</span>
+                      <span>8</span>
                       <span>9</span>
+                      <span class="elim">0</span>
                     </div>
                   </div>
                   <span class="htp-arrow" aria-hidden="true">→</span>

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
                 <div class="htp-worked">
                   <div class="digit-box htp-box">
                     <div class="digit-box__grid four-col">
+                      <span class="elim">0</span>
                       <span>1</span>
                       <span>2</span>
                       <span>3</span>
@@ -107,7 +108,6 @@
                       <span>7</span>
                       <span>8</span>
                       <span>9</span>
-                      <span class="elim">0</span>
                     </div>
                   </div>
                   <span class="htp-arrow" aria-hidden="true">→</span>

--- a/index.html
+++ b/index.html
@@ -97,15 +97,16 @@
                 <p class="modal-step-label">2. Open the digit boxes, remove ineligible digits</p>
                 <div class="htp-worked">
                   <div class="digit-box htp-box">
-                    <div class="digit-box__grid">
+                    <div class="digit-box__grid four-col">
+                      <span class="elim">0</span>
                       <span>1</span>
                       <span>2</span>
                       <span>3</span>
                       <span>4</span>
-                      <span>5</span>
+                      <span class="digit-box__mid">5</span>
                       <span>6</span>
                       <span>7</span>
-                      <span>8</span>
+                      <span class="digit-box__mid">8</span>
                       <span>9</span>
                     </div>
                   </div>

--- a/src/app.ts
+++ b/src/app.ts
@@ -341,7 +341,7 @@ function renderBox(i: number): void {
   } else {
     // 3-4-3 grid for all boxes (1-9 then 0)
     // Box 0 (hundreds): 0 is always eliminated since numbers are 100–999
-    const spans = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+    const spans = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       .map((d) => {
         const isElim = (i === 0 && d === 0) || !s.has(d);
         return `<span${isElim ? ' class="elim"' : ""}>${d}</span>`;
@@ -361,7 +361,7 @@ function renderAllBoxes() {
 
 function buildKeypad() {
   if (!dom.keypad || activeBox === null) return;
-  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+  const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   dom.keypad.innerHTML = "";
   for (const d of digits) {
     const btn = document.createElement("button");

--- a/src/app.ts
+++ b/src/app.ts
@@ -363,16 +363,20 @@ function renderAllBoxes() {
 
 function buildKeypad() {
   if (!dom.keypad || activeBox === null) return;
-  // Box 0 (hundreds) cannot be 0
-  const digits = activeBox === 0 ? [1, 2, 3, 4, 5, 6, 7, 8, 9] : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   dom.keypad.innerHTML = "";
   for (const d of digits) {
     const btn = document.createElement("button");
     btn.type = "button";
-    btn.className = "keypad__btn" + (possibles[activeBox].has(d) ? "" : " elim");
+    const disabled = activeBox === 0 && d === 0;
+    btn.className = "keypad__btn" + (disabled || !possibles[activeBox].has(d) ? " elim" : "");
     btn.textContent = String(d);
     btn.setAttribute("aria-label", `Toggle digit ${d}`);
-    btn.addEventListener("click", () => toggleDigit(d));
+    if (disabled) {
+      btn.disabled = true;
+    } else {
+      btn.addEventListener("click", () => toggleDigit(d));
+    }
     dom.keypad.appendChild(btn);
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -361,7 +361,7 @@ function renderAllBoxes() {
 
 function buildKeypad() {
   if (!dom.keypad || activeBox === null) return;
-  const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
   dom.keypad.innerHTML = "";
   for (const d of digits) {
     const btn = document.createElement("button");

--- a/src/app.ts
+++ b/src/app.ts
@@ -339,14 +339,12 @@ function renderBox(i: number): void {
   if (s.size === 1) {
     el.innerHTML = `<span class="digit-box__resolved">${[...s][0]}</span>`;
   } else {
-    // 4-col grid for all boxes (digits 0–9); 5 and 8 span 2 cols
+    // 3-4-3 grid for all boxes (1-9 then 0)
     // Box 0 (hundreds): 0 is always eliminated since numbers are 100–999
-    const spans = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    const spans = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
       .map((d) => {
-        const isMid = d === 5 || d === 8;
         const isElim = (i === 0 && d === 0) || !s.has(d);
-        const cls = [isMid && "digit-box__mid", isElim && "elim"].filter(Boolean).join(" ");
-        return `<span${cls ? ` class="${cls}"` : ""}>${d}</span>`;
+        return `<span${isElim ? ' class="elim"' : ""}>${d}</span>`;
       })
       .join("");
     el.innerHTML = `<div class="digit-box__grid four-col">${spans}</div>`;

--- a/src/app.ts
+++ b/src/app.ts
@@ -363,7 +363,7 @@ function renderAllBoxes() {
 
 function buildKeypad() {
   if (!dom.keypad || activeBox === null) return;
-  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+  const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   dom.keypad.innerHTML = "";
   for (const d of digits) {
     const btn = document.createElement("button");

--- a/src/app.ts
+++ b/src/app.ts
@@ -363,7 +363,7 @@ function renderAllBoxes() {
 
 function buildKeypad() {
   if (!dom.keypad || activeBox === null) return;
-  const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
   dom.keypad.innerHTML = "";
   for (const d of digits) {
     const btn = document.createElement("button");

--- a/src/app.ts
+++ b/src/app.ts
@@ -338,18 +338,13 @@ function renderBox(i: number): void {
 
   if (s.size === 1) {
     el.innerHTML = `<span class="digit-box__resolved">${[...s][0]}</span>`;
-  } else if (i === 0) {
-    // 3×3 grid for hundreds box (digits 1–9)
-    const spans = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-      .map((d) => `<span${s.has(d) ? "" : ' class="elim"'}>${d}</span>`)
-      .join("");
-    el.innerHTML = `<div class="digit-box__grid">${spans}</div>`;
   } else {
-    // 4-col grid for tens/units boxes (digits 0–9); 5 and 8 span 2 cols
+    // 4-col grid for all boxes (digits 0–9); 5 and 8 span 2 cols
+    // Box 0 (hundreds): 0 is always eliminated since numbers are 100–999
     const spans = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       .map((d) => {
         const isMid = d === 5 || d === 8;
-        const isElim = !s.has(d);
+        const isElim = (i === 0 && d === 0) || !s.has(d);
         const cls = [isMid && "digit-box__mid", isElim && "elim"].filter(Boolean).join(" ");
         return `<span${cls ? ` class="${cls}"` : ""}>${d}</span>`;
       })

--- a/src/style.css
+++ b/src/style.css
@@ -610,18 +610,9 @@
   .keypad__grid,
   .demo-keypad {
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     gap: 0.4375rem;
     inline-size: 100%;
-  }
-
-  .keypad__btn {
-    grid-column: span 3;
-  }
-
-  .keypad__btn:nth-child(-n+3),
-  .keypad__btn:nth-child(n+8) {
-    grid-column: span 4;
   }
 
   .demo-keypad {

--- a/src/style.css
+++ b/src/style.css
@@ -610,9 +610,18 @@
   .keypad__grid,
   .demo-keypad {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(12, 1fr);
     gap: 0.4375rem;
     inline-size: 100%;
+  }
+
+  .keypad__btn {
+    grid-column: span 3;
+  }
+
+  .keypad__btn:nth-child(-n+3),
+  .keypad__btn:nth-child(n+8) {
+    grid-column: span 4;
   }
 
   .demo-keypad {

--- a/src/style.css
+++ b/src/style.css
@@ -569,7 +569,11 @@
     padding: 0.375rem;
 
     &.four-col {
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(12, 1fr);
+
+      & span { grid-column: span 3; }
+      & span:nth-child(-n+3),
+      & span:nth-child(n+8) { grid-column: span 4; }
     }
 
     & span {


### PR DESCRIPTION
## Summary
- All three digit boxes now use the same 0-9 grid layout (3-4-3 rows)
- Hundreds box shows 0 permanently faded since answers are 100-999
- Keypad shows 0-9 in order, with 0 disabled for hundreds box
- Updated HTP modal example to match

## Test plan
- [ ] Digit boxes show 0-9 in 3-4-3 layout
- [ ] Hundreds box 0 always faded
- [ ] Keypad shows 0-9, 0 disabled for hundreds
- [ ] Eliminating digits still works correctly
- [ ] HTP modal looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)