### PR TITLE
Move puzzle logic server-side with answer validation API (#95)

### DIFF
--- a/docs/SELF-REVIEW.md
+++ b/docs/SELF-REVIEW.md
@@ -50,6 +50,6 @@ This is a **living document** — when a review catches something the self-revie
 
 ## Worker / service worker
 
-- Does the Worker still inject `window.PUZZLE_DATA` correctly for both `/` and `/random` routes?
+- Do API responses from the Worker avoid sending the answer to the client?
 - Does `sw.js` cache versioning align with any changed assets?
-- No accidental caching of puzzle data (daily puzzles must be fresh)
+- No accidental caching of API responses (puzzle data and guess validation must be fresh)

--- a/index.html
+++ b/index.html
@@ -293,84 +293,39 @@
           <div class="card__label" data-plabel>Puzzle #7 · 14 March 2026</div>
 
           <div class="clue-list" role="list" aria-label="Puzzle clues">
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">CUBE</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The third digit is</div>
-                <div class="clue__line2">a cube number</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">RANGE</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The range of all three digits is</div>
-                <div class="clue__line2">= 5</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">MEAN</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The mean of all three digits is</div>
-                <div class="clue__line2">
-                  ≠ 2.
-                  <span style="display: inline-block; position: relative">
-                    3
-                    <span style="position: absolute; left: 50%; top: -0.55em; transform: translateX(-50%); font-size: 1.4rem; line-height: 1">·</span>
-                  </span>
-                </div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">SUM</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The sum of the 1st and 3rd digits is</div>
-                <div class="clue__line2">≤ 2</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">PROD</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The product of the 2nd and 3rd digits is</div>
-                <div class="clue__line2">≤ 0</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
         <div id="puzzle" class="card" data-card>
           <div class="card__label" data-plabel>Puzzle #7 · 14 March 2026</div>
 
-          <div class="clue-list" role="list" aria-label="Puzzle clues">
+          <div class="clue-list" role="list" aria-label="Puzzle clues" aria-busy="true">
             <div class="clue-skeleton" aria-hidden="true">
               <div class="clue-skeleton__tag"></div>
               <div class="clue-skeleton__lines">

--- a/public/sw.js
+++ b/public/sw.js
@@ -34,7 +34,7 @@ self.addEventListener('activate', (e) => {
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
 
-  // Network-first for navigation (gets fresh puzzle data injected by Worker)
+  // Network-first for navigation (gets fresh HTML from Worker)
   if (e.request.mode === 'navigate') {
     e.respondWith(
       fetch(e.request)
@@ -45,6 +45,11 @@ self.addEventListener('fetch', (e) => {
         })
         .catch(() => caches.match(e.request))
     );
+    return;
+  }
+
+  // Network-only for API routes (never cache puzzle data or guess responses)
+  if (url.origin === self.location.origin && url.pathname.startsWith('/api/')) {
     return;
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -716,9 +716,13 @@ document.querySelector('[data-swatches]')?.addEventListener('click', (e) => {
 
 // ─── Dev helpers (non-production only) ───────────────────────────────────────
 
-window._devFillAnswer = () => {
-  if (!gameState.answer) return;
-  const digits = [Math.floor(gameState.answer / 100), Math.floor((gameState.answer % 100) / 10), gameState.answer % 10];
-  digits.forEach((d, i) => { possibles[i] = new Set([d]); renderBox(i); });
-  checkSubmit();
+window._devFillAnswer = async () => {
+  try {
+    const res = await fetch('/api/dev/answer');
+    if (!res.ok) return;
+    const { answer } = await res.json() as { answer: number };
+    const digits = [Math.floor(answer / 100), Math.floor((answer % 100) / 10), answer % 10];
+    digits.forEach((d, i) => { possibles[i] = new Set([d]); renderBox(i); });
+    checkSubmit();
+  } catch { /* dev only */ }
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 // Clumeral — app.ts
-// Puzzle data is injected by the Worker as window.PUZZLE_DATA.
+// Puzzle data is fetched from the API. The answer never reaches the client.
 
 import type { GameState, ClueData } from './types.ts';
 import { launchConfetti } from './confetti.ts';
@@ -64,6 +64,7 @@ const dom = {
 
 let gameState: GameState = { answer: null, guesses: [], solved: false };
 let saveScore = true;
+let submitting = false; // guard against double-submit during API call
 
 function initPossibles(): Set<number>[] {
   return [
@@ -469,37 +470,34 @@ function resetPuzzleUI() {
   checkSubmit();
 }
 
-function startRandomPuzzle(puzzleData: { answer: number; clues: ClueData[] }): void {
-  const { answer, clues } = puzzleData;
-
+function startRandomPuzzle(clues: ClueData[], token: string): void {
   if (dom.plabel) dom.plabel.textContent = "Random puzzle";
 
   renderClues(clues);
 
-  gameState = { answer, guesses: [], solved: false, isRandom: true };
+  gameState = { answer: null, guesses: [], solved: false, isRandom: true, token };
   resetPuzzleUI();
   track("puzzle_start");
 
   dom.again?.classList.add("hidden");
-  // No score saving for random puzzles
   dom.save?.classList.add("hidden");
 }
 
-function startDailyPuzzle(puzzleData: { date: string; puzzleNumber: number; answer: number; clues: ClueData[] }): void {
-  const { date, puzzleNumber: num, answer, clues } = puzzleData;
-
+function startDailyPuzzle(date: string, num: number, clues: ClueData[]): void {
   if (dom.plabel) dom.plabel.textContent = `Puzzle #${num} · ${formatDate(date)}`;
 
   renderClues(clues);
 
   const entry = todayEntry();
   if (entry) {
-    gameState = { answer, guesses: [], solved: true, puzzleNum: num };
+    // Already solved — we don't have the answer from the API, but we don't need it
+    // for the completed state display. The digit boxes stay empty (no answer to show).
+    gameState = { answer: null, guesses: [], solved: true, puzzleNum: num, date };
     showCompletedState(entry.tries);
     return;
   }
 
-  gameState = { answer, guesses: [], solved: false, puzzleNum: num };
+  gameState = { answer: null, guesses: [], solved: false, puzzleNum: num, date };
   resetPuzzleUI();
   track("puzzle_start");
   const htpWasSeen = localStorage.getItem("cw-htp-seen");
@@ -513,60 +511,98 @@ function startDailyPuzzle(puzzleData: { date: string; puzzleNumber: number; answ
   if (dom.saveCheck) dom.saveCheck.checked = saveScore;
 }
 
-function handleGuess() {
-  if (gameState.solved) return;
+async function handleGuess() {
+  if (gameState.solved || submitting) return;
   if (!possibles.every((s) => s.size === 1)) return;
 
   const guessStr = possibles.map((s) => [...s][0]).join("");
   const guess = Number(guessStr);
   const tries = gameState.guesses.length + 1;
 
-  if (guess === gameState.answer) {
-    gameState.solved = true;
-    track("puzzle_complete", tries);
-    launchConfetti();
-    renderFeedback("correct", gameState.answer ?? undefined);
-    closeKeypad();
-    dom.digits?.classList.add("digit-correct");
-    dom.submitWrap?.classList.remove("visible");
-    celebrateOcto();
-    if (gameState.isRandom) {
-      dom.again?.classList.remove("hidden");
-    } else {
-      if (saveScore) {
-        recordGame(todayLocal(), tries);
-        renderStats();
-      }
-      showNextPuzzle();
+  // Build request body
+  const body: { guess: number; date?: string; token?: string } = { guess };
+  if (gameState.token) {
+    body.token = gameState.token;
+  } else if (gameState.date) {
+    body.date = gameState.date;
+  }
+
+  submitting = true;
+  dom.submitBtn?.setAttribute("disabled", "true");
+
+  try {
+    const res = await fetch("/api/guess", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      renderFeedback("incorrect");
+      return;
     }
-  } else {
-    gameState.guesses.push(guess);
-    track("incorrect_guess");
+
+    const result = await res.json() as { correct: boolean };
+
+    if (result.correct) {
+      gameState.solved = true;
+      gameState.answer = guess; // now we know the answer (it was our correct guess)
+      track("puzzle_complete", tries);
+      launchConfetti();
+      renderFeedback("correct", guess);
+      closeKeypad();
+      dom.digits?.classList.add("digit-correct");
+      dom.submitWrap?.classList.remove("visible");
+      celebrateOcto();
+      if (gameState.isRandom) {
+        dom.again?.classList.remove("hidden");
+      } else {
+        if (saveScore) {
+          recordGame(todayLocal(), tries);
+          renderStats();
+        }
+        showNextPuzzle();
+      }
+    } else {
+      gameState.guesses.push(guess);
+      track("incorrect_guess");
+      renderFeedback("incorrect");
+      renderHistory(gameState.guesses);
+      sadOcto();
+      dom.submitWrap?.classList.remove("visible");
+    }
+  } catch {
     renderFeedback("incorrect");
-    renderHistory(gameState.guesses);
-    sadOcto();
-    // Keep digits filled but hide submit — user can tap a box to change their guess
-    dom.submitWrap?.classList.remove("visible");
+  } finally {
+    submitting = false;
+    dom.submitBtn?.removeAttribute("disabled");
   }
 }
 
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
-function loadPuzzle() {
-  if (window.PUZZLE_DATA) {
-    if (window.PUZZLE_DATA.isRandom) {
-      startRandomPuzzle(window.PUZZLE_DATA);
+async function loadPuzzle() {
+  const isRandom = window.location.pathname === '/random';
+  const endpoint = isRandom ? '/api/puzzle/random' : '/api/puzzle';
+
+  try {
+    const res = await fetch(endpoint);
+    if (!res.ok) throw new Error(`API ${res.status}`);
+
+    const data = await res.json() as any;
+
+    if (isRandom) {
+      startRandomPuzzle(data.clues, data.token);
     } else {
-      const pd = window.PUZZLE_DATA;
-      if (pd.date && pd.puzzleNumber !== undefined) {
-        startDailyPuzzle({ date: pd.date, puzzleNumber: pd.puzzleNumber, answer: pd.answer, clues: pd.clues });
-      }
+      startDailyPuzzle(data.date, data.puzzleNumber, data.clues);
     }
-  } else {
+  } catch {
     if (dom.feedback) {
-      dom.feedback.textContent = 'Puzzle data not available. Please refresh the page.';
+      dom.feedback.textContent = 'Could not load the puzzle. Please refresh the page.';
       dom.feedback.classList.remove('hidden');
     }
+    // Hide skeleton on error
+    if (dom.clueList) dom.clueList.innerHTML = '';
   }
 }
 
@@ -588,7 +624,7 @@ for (let i = 0; i < 3; i++) {
 }
 
 // Submit button
-dom.submitBtn?.addEventListener("click", handleGuess);
+dom.submitBtn?.addEventListener("click", () => { handleGuess(); });
 
 // Save checkbox
 if (dom.saveCheck) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -203,6 +203,7 @@ function closeTagTip(): void {
 
 function renderClues(clues: ClueData[]): void {
   if (!dom.clueList) return;
+  dom.clueList.removeAttribute("aria-busy");
   dom.clueList.innerHTML = "";
   for (const { propKey, label, operator, value } of clues) {
     const tag = getClueTag(propKey);
@@ -279,6 +280,12 @@ function renderFeedback(type: string | null, answer?: number): void {
   } else if (type === "incorrect") {
     if (dom.feedback) {
       dom.feedback.innerHTML = `${ICON_CROSS} Incorrect — try again.`;
+      dom.feedback.className = "feedback feedback--incorrect";
+      dom.feedback.classList.remove("hidden");
+    }
+  } else if (type === "error") {
+    if (dom.feedback) {
+      dom.feedback.innerHTML = `${ICON_CROSS} Something went wrong — please try again.`;
       dom.feedback.className = "feedback feedback--incorrect";
       dom.feedback.classList.remove("hidden");
     }
@@ -490,9 +497,7 @@ function startDailyPuzzle(date: string, num: number, clues: ClueData[]): void {
 
   const entry = todayEntry();
   if (entry) {
-    // Already solved — we don't have the answer from the API, but we don't need it
-    // for the completed state display. The digit boxes stay empty (no answer to show).
-    gameState = { answer: null, guesses: [], solved: true, puzzleNum: num, date };
+    gameState = { answer: entry.answer ?? null, guesses: [], solved: true, puzzleNum: num, date };
     showCompletedState(entry.tries);
     return;
   }
@@ -525,6 +530,9 @@ async function handleGuess() {
     body.token = gameState.token;
   } else if (gameState.date) {
     body.date = gameState.date;
+  } else {
+    renderFeedback("error");
+    return;
   }
 
   submitting = true;
@@ -538,7 +546,7 @@ async function handleGuess() {
     });
 
     if (!res.ok) {
-      renderFeedback("incorrect");
+      renderFeedback("error");
       return;
     }
 
@@ -558,7 +566,7 @@ async function handleGuess() {
         dom.again?.classList.remove("hidden");
       } else {
         if (saveScore) {
-          recordGame(todayLocal(), tries);
+          recordGame(todayLocal(), tries, guess);
           renderStats();
         }
         showNextPuzzle();
@@ -572,7 +580,7 @@ async function handleGuess() {
       dom.submitWrap?.classList.remove("visible");
     }
   } catch {
-    renderFeedback("incorrect");
+    renderFeedback("error");
   } finally {
     submitting = false;
     dom.submitBtn?.removeAttribute("disabled");

--- a/src/app.ts
+++ b/src/app.ts
@@ -718,7 +718,8 @@ document.querySelector('[data-swatches]')?.addEventListener('click', (e) => {
 
 window._devFillAnswer = async () => {
   try {
-    const res = await fetch('/api/dev/answer');
+    const params = gameState.token ? `?token=${encodeURIComponent(gameState.token)}` : '';
+    const res = await fetch(`/api/dev/answer${params}`);
     if (!res.ok) return;
     const { answer } = await res.json() as { answer: number };
     const digits = [Math.floor(answer / 100), Math.floor((answer % 100) / 10), answer % 10];

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,8 +1,5 @@
-import type { PuzzleData } from './types.ts';
-
 declare global {
   interface Window {
-    PUZZLE_DATA?: PuzzleData;
     _swapIcons?: (colourName: string) => void;
     _currentColour?: string;
     _devFillAnswer?: () => void;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -26,8 +26,8 @@ export function loadHistory(): HistoryEntry[] {
   }
 }
 
-export function recordGame(dateStr: string, tries: number): void {
+export function recordGame(dateStr: string, tries: number, answer?: number): void {
   const history = loadHistory().filter((h) => h.date !== dateStr);
-  history.unshift({ date: dateStr, tries });
+  history.unshift({ date: dateStr, tries, ...(answer != null && { answer }) });
   localStorage.setItem(STORAGE_HISTORY, JSON.stringify(history.slice(0, 60)));
 }

--- a/src/style.css
+++ b/src/style.css
@@ -502,6 +502,48 @@
   }
 
   /* ═══════════════════════════════════════
+     Clue skeleton (loading state)
+     ═══════════════════════════════════════ */
+
+  @keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+  }
+
+  .clue-skeleton {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    align-items: center;
+  }
+
+  .clue-skeleton__tag {
+    width: 4rem;
+    height: 2rem;
+    border-radius: 0.375rem;
+    background: linear-gradient(90deg, var(--border) 25%, var(--surface) 50%, var(--border) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite ease-in-out;
+  }
+
+  .clue-skeleton__lines {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .clue-skeleton__line {
+    height: 0.85rem;
+    border-radius: 0.25rem;
+    background: linear-gradient(90deg, var(--border) 25%, var(--surface) 50%, var(--border) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite ease-in-out;
+  }
+
+  .clue-skeleton__line--long { width: 80%; }
+  .clue-skeleton__line--short { width: 40%; }
+
+  /* ═══════════════════════════════════════
      Digit entry boxes
      ═══════════════════════════════════════ */
   .digits {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,20 +5,14 @@ export interface ClueData {
   value: number | boolean;
 }
 
-export interface PuzzleData {
-  date?: string;
-  puzzleNumber?: number;
-  answer: number;
-  clues: ClueData[];
-  isRandom?: boolean;
-}
-
 export interface GameState {
   answer: number | null;
   guesses: number[];
   solved: boolean;
   puzzleNum?: number;
   isRandom?: boolean;
+  date?: string;
+  token?: string;
 }
 
 export interface HistoryEntry {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface GameState {
 export interface HistoryEntry {
   date: string;
   tries: number;
+  answer?: number;
 }
 
 export interface Prefs {

--- a/src/worker/crypto.ts
+++ b/src/worker/crypto.ts
@@ -1,11 +1,11 @@
-// HMAC helpers for signing random puzzle tokens.
+// Crypto helpers for random puzzle tokens.
 // Uses Web Crypto API (available in Cloudflare Workers).
-
-const ALGORITHM = { name: 'HMAC', hash: 'SHA-256' } as const;
+// Tokens are AES-GCM encrypted seeds — opaque to the client.
 
 async function getKey(secret: string): Promise<CryptoKey> {
   const enc = new TextEncoder();
-  return crypto.subtle.importKey('raw', enc.encode(secret), ALGORITHM, false, ['sign', 'verify']);
+  const raw = await crypto.subtle.digest('SHA-256', enc.encode(secret));
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', false, ['encrypt', 'decrypt']);
 }
 
 function toHex(buf: ArrayBuffer): string {
@@ -20,28 +20,37 @@ function fromHex(hex: string): Uint8Array {
   return bytes;
 }
 
-/** Sign a random seed, returning `seed.hmac` token string. */
+/** Encrypt a random seed into an opaque token string. */
 export async function signToken(seed: number, secret: string): Promise<string> {
   const key = await getKey(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
   const data = new TextEncoder().encode(String(seed));
-  const sig = await crypto.subtle.sign('HMAC', key, data);
-  return `${seed}.${toHex(sig)}`;
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+  return toHex(iv.buffer as ArrayBuffer) + '.' + toHex(ciphertext);
 }
 
-/** Parse and verify a `seed.hmac` token. Returns the seed if valid, null otherwise. */
+/** Decrypt a token back to the seed. Returns the seed if valid, null otherwise. */
 export async function verifyToken(token: string, secret: string): Promise<number | null> {
   const dotIdx = token.indexOf('.');
   if (dotIdx < 1) return null;
 
-  const seedStr = token.slice(0, dotIdx);
-  const hmacHex = token.slice(dotIdx + 1);
-  const seed = Number(seedStr);
-  if (!Number.isFinite(seed) || seed !== Math.floor(seed)) return null;
+  const ivHex = token.slice(0, dotIdx);
+  const ctHex = token.slice(dotIdx + 1);
 
-  const key = await getKey(secret);
-  const data = new TextEncoder().encode(seedStr);
-  const sig = fromHex(hmacHex);
-  const valid = await crypto.subtle.verify('HMAC', key, sig.buffer as ArrayBuffer, data);
-
-  return valid ? seed : null;
+  try {
+    const key = await getKey(secret);
+    const iv = fromHex(ivHex);
+    const ct = fromHex(ctHex);
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+      key,
+      ct.buffer as ArrayBuffer,
+    );
+    const seedStr = new TextDecoder().decode(plaintext);
+    const seed = Number(seedStr);
+    if (!Number.isFinite(seed) || seed !== Math.floor(seed)) return null;
+    return seed;
+  } catch {
+    return null;
+  }
 }

--- a/src/worker/crypto.ts
+++ b/src/worker/crypto.ts
@@ -1,0 +1,47 @@
+// HMAC helpers for signing random puzzle tokens.
+// Uses Web Crypto API (available in Cloudflare Workers).
+
+const ALGORITHM = { name: 'HMAC', hash: 'SHA-256' } as const;
+
+async function getKey(secret: string): Promise<CryptoKey> {
+  const enc = new TextEncoder();
+  return crypto.subtle.importKey('raw', enc.encode(secret), ALGORITHM, false, ['sign', 'verify']);
+}
+
+function toHex(buf: ArrayBuffer): string {
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/** Sign a random seed, returning `seed.hmac` token string. */
+export async function signToken(seed: number, secret: string): Promise<string> {
+  const key = await getKey(secret);
+  const data = new TextEncoder().encode(String(seed));
+  const sig = await crypto.subtle.sign('HMAC', key, data);
+  return `${seed}.${toHex(sig)}`;
+}
+
+/** Parse and verify a `seed.hmac` token. Returns the seed if valid, null otherwise. */
+export async function verifyToken(token: string, secret: string): Promise<number | null> {
+  const dotIdx = token.indexOf('.');
+  if (dotIdx < 1) return null;
+
+  const seedStr = token.slice(0, dotIdx);
+  const hmacHex = token.slice(dotIdx + 1);
+  const seed = Number(seedStr);
+  if (!Number.isFinite(seed) || seed !== Math.floor(seed)) return null;
+
+  const key = await getKey(secret);
+  const data = new TextEncoder().encode(seedStr);
+  const sig = fromHex(hmacHex);
+  const valid = await crypto.subtle.verify('HMAC', key, sig.buffer as ArrayBuffer, data);
+
+  return valid ? seed : null;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -126,6 +126,14 @@ export default {
       return handleGuess(request, env);
     }
 
+    // Dev-only: return today's answer (blocked on production domain)
+    if (request.method === 'GET' && url.pathname === '/api/dev/answer') {
+      if (url.hostname === 'clumeral.com') return new Response('Not found', { status: 404 });
+      const today = todayLocal();
+      const puzzle = await getDailyPuzzle(env, today);
+      return json({ answer: puzzle.answer });
+    }
+
     // ── Analytics ──
 
     if (request.method === 'POST' && url.pathname === '/api/event') {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -26,13 +26,10 @@ const VALID_EVENTS = new Set([
   'theme_toggle', 'colour_change', 'tooltip_opened',
 ]);
 
-const JSON_HEADERS = { 'Content-Type': 'application/json' };
-const CORS_HEADERS = { 'Access-Control-Allow-Origin': '*' };
-
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { ...JSON_HEADERS, ...CORS_HEADERS },
+    headers: { 'Content-Type': 'application/json' },
   });
 }
 
@@ -98,6 +95,9 @@ async function handleGuess(request: Request, env: Env): Promise<Response> {
   if (body.date) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
       return json({ error: 'Invalid date format' }, 400);
+    }
+    if (body.date > todayLocal()) {
+      return json({ error: 'Cannot guess future puzzles' }, 400);
     }
     const puzzle = await getDailyPuzzle(env, body.date);
     return json({ correct: guess === puzzle.answer });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,13 +1,23 @@
-// Worker entry point — intercepts GET / and /random to inject puzzle data into HTML.
+// Worker entry point — serves API routes for puzzle data and guess validation.
+// The answer is never sent to the client.
 
 import { runFilterLoop, makeRng, dateSeedInt, todayLocal, puzzleNumber } from './puzzle.ts';
+import { signToken, verifyToken } from './crypto.ts';
 import { getStats, renderDashboard } from './stats.ts';
 
 interface Env {
   ASSETS: { fetch: (req: Request) => Promise<Response> };
   ANALYTICS: AnalyticsEngineDataset;
+  PUZZLES: KVNamespace;
+  HMAC_SECRET: string;
   CF_ACCOUNT_ID: string;
   CF_API_TOKEN: string;
+}
+
+interface StoredPuzzle {
+  answer: number;
+  clues: { propKey: string; label: string; operator: string; value: number | boolean }[];
+  puzzleNumber: number;
 }
 
 const VALID_EVENTS = new Set([
@@ -16,53 +26,108 @@ const VALID_EVENTS = new Set([
   'theme_toggle', 'colour_change', 'tooltip_opened',
 ]);
 
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const CORS_HEADERS = { 'Access-Control-Allow-Origin': '*' };
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...JSON_HEADERS, ...CORS_HEADERS },
+  });
+}
+
+// ─── Puzzle generation + KV caching ──────────────────────────────────────────
+
+async function getDailyPuzzle(env: Env, date: string): Promise<StoredPuzzle> {
+  // Try KV first
+  const cached = await env.PUZZLES.get<StoredPuzzle>(date, 'json');
+  if (cached) return cached;
+
+  // Generate and store
+  const rng = makeRng(dateSeedInt(date));
+  const { answer, clues } = runFilterLoop(rng);
+  const puzzle: StoredPuzzle = { answer, clues, puzzleNumber: puzzleNumber(date) };
+  await env.PUZZLES.put(date, JSON.stringify(puzzle));
+  return puzzle;
+}
+
+// ─── Route handlers ──────────────────────────────────────────────────────────
+
+async function handleGetPuzzle(env: Env): Promise<Response> {
+  const today = todayLocal();
+  const puzzle = await getDailyPuzzle(env, today);
+  return json({
+    date: today,
+    puzzleNumber: puzzle.puzzleNumber,
+    clues: puzzle.clues,
+  });
+}
+
+async function handleGetRandomPuzzle(env: Env): Promise<Response> {
+  const seed = Math.floor(Math.random() * 0xFFFFFFFF);
+  const rng = makeRng(seed);
+  const { clues } = runFilterLoop(rng);
+  const token = await signToken(seed, env.HMAC_SECRET);
+  return json({ isRandom: true, clues, token });
+}
+
+async function handleGuess(request: Request, env: Env): Promise<Response> {
+  let body: { date?: string; token?: string; guess?: number };
+  try {
+    body = await request.json() as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { guess } = body;
+  if (typeof guess !== 'number' || !Number.isInteger(guess) || guess < 100 || guess > 999) {
+    return json({ error: 'Guess must be an integer between 100 and 999' }, 400);
+  }
+
+  // Random puzzle — verify token and re-derive answer
+  if (body.token) {
+    const seed = await verifyToken(body.token, env.HMAC_SECRET);
+    if (seed === null) return json({ error: 'Invalid token' }, 400);
+
+    const rng = makeRng(seed);
+    const { answer } = runFilterLoop(rng);
+    return json({ correct: guess === answer });
+  }
+
+  // Daily puzzle — look up from KV
+  if (body.date) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
+      return json({ error: 'Invalid date format' }, 400);
+    }
+    const puzzle = await getDailyPuzzle(env, body.date);
+    return json({ correct: guess === puzzle.answer });
+  }
+
+  return json({ error: 'Provide either date or token' }, 400);
+}
+
+// ─── Main fetch handler ──────────────────────────────────────────────────────
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
-      const today = todayLocal();
-      const rng = makeRng(dateSeedInt(today));
-      const { answer, clues } = runFilterLoop(rng);
-      const puzzleData = { date: today, puzzleNumber: puzzleNumber(today), answer, clues };
+    // ── API routes ──
 
-      // Fetch static index.html from Pages assets, inject puzzle data before </head>
-      const assetRes = await env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
-      const html = await assetRes.text();
-      const injected = html.replace(
-        '</head>',
-        `<script>window.PUZZLE_DATA=${JSON.stringify(puzzleData)}</script></head>`
-      );
-
-      return new Response(injected, {
-        headers: { 'Content-Type': 'text/html; charset=utf-8' },
-      });
+    if (request.method === 'GET' && url.pathname === '/api/puzzle') {
+      return handleGetPuzzle(env);
     }
 
-    if (request.method === 'GET' && url.pathname === '/random') {
-      try {
-        const seed = Math.floor(Math.random() * 0xFFFFFFFF);
-        const rng = makeRng(seed);
-        const { answer, clues } = runFilterLoop(rng);
-        const puzzleData = { isRandom: true, answer, clues };
-
-        const assetRes = await env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
-        const html = await assetRes.text();
-        const injected = html.replace(
-          '</head>',
-          `<script>window.PUZZLE_DATA=${JSON.stringify(puzzleData)}</script></head>`
-        );
-
-        return new Response(injected, {
-          headers: { 'Content-Type': 'text/html; charset=utf-8' },
-        });
-      } catch (err: unknown) {
-        const e = err instanceof Error ? err : new Error(String(err));
-        return new Response(`/random error: ${e.message}\n${e.stack}`, { status: 500 });
-      }
+    if (request.method === 'GET' && url.pathname === '/api/puzzle/random') {
+      return handleGetRandomPuzzle(env);
     }
 
-    // POST /api/event — record an analytics event
+    if (request.method === 'POST' && url.pathname === '/api/guess') {
+      return handleGuess(request, env);
+    }
+
+    // ── Analytics ──
+
     if (request.method === 'POST' && url.pathname === '/api/event') {
       try {
         const body = await request.json() as { event?: string; uid?: string; value?: number; newUser?: boolean; source?: string };
@@ -81,7 +146,8 @@ export default {
       }
     }
 
-    // GET /api/stats — JSON stats data
+    // ── Stats ──
+
     if (request.method === 'GET' && url.pathname === '/api/stats') {
       try {
         if (!env.CF_ACCOUNT_ID || !env.CF_API_TOKEN) {
@@ -98,7 +164,6 @@ export default {
       }
     }
 
-    // GET /stats — rendered dashboard
     if (request.method === 'GET' && url.pathname === '/stats') {
       try {
         if (!env.CF_ACCOUNT_ID || !env.CF_API_TOKEN) {
@@ -122,6 +187,19 @@ export default {
       }
     }
 
+    // ── Static pages ──
+
+    // GET / and /random — serve static HTML (client fetches puzzle via API)
+    if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html' || url.pathname === '/random')) {
+      return env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
+    }
+
     return env.ASSETS.fetch(request);
+  },
+
+  // ── Cron: pre-generate today's puzzle at midnight UTC ──
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    const today = todayLocal();
+    await getDailyPuzzle(env, today);
   },
 };

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -126,9 +126,17 @@ export default {
       return handleGuess(request, env);
     }
 
-    // Dev-only: return today's answer (blocked on production domain)
+    // Dev-only: return the answer for the current puzzle (blocked on production domain)
     if (request.method === 'GET' && url.pathname === '/api/dev/answer') {
       if (url.hostname === 'clumeral.com') return new Response('Not found', { status: 404 });
+      const token = url.searchParams.get('token');
+      if (token) {
+        const seed = await verifyToken(token, env.HMAC_SECRET);
+        if (seed === null) return json({ error: 'Invalid token' }, 400);
+        const rng = makeRng(seed);
+        const { answer } = runFilterLoop(rng);
+        return json({ answer });
+      }
       const today = todayLocal();
       const puzzle = await getDailyPuzzle(env, today);
       return json({ answer: puzzle.answer });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,7 @@
   "kv_namespaces": [
     {
       "binding": "PUZZLES",
-      "id": "PLACEHOLDER_PROD_ID"
+      "id": "d07cfc9a455943e3839967475925a468"
     }
   ],
   "triggers": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,5 +11,14 @@
       "binding": "ANALYTICS",
       "dataset": "clumeral"
     }
-  ]
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "PUZZLES",
+      "id": "PLACEHOLDER_PROD_ID"
+    }
+  ],
+  "triggers": {
+    "crons": ["0 0 * * *"]
+  }
 }


### PR DESCRIPTION
## Summary
- Replace client-side answer exposure with server-side API (`GET /api/puzzle`, `GET /api/puzzle/random`, `POST /api/guess`)
- Daily puzzles cached in Cloudflare KV with cron pre-generation at midnight UTC
- Random puzzle tokens encrypted with AES-GCM (opaque to client)
- Client shows skeleton shimmer while loading clues from API
- Service worker excludes `/api/*` from cache
- Future-date guesses blocked, CORS removed (same-origin only)
- Solved answer stored in localStorage so returning players see their result
- Dev helper (`_devFillAnswer`) fetches from dev-only endpoint (blocked on clumeral.com)

## Test plan
- [ ] Daily puzzle loads and clues display correctly
- [ ] Random puzzle loads at `/random` with different clues each time
- [ ] Correct guess shows confetti and completion state
- [ ] Incorrect guess shows feedback and allows retry
- [ ] Returning to a solved daily puzzle shows completed state with answer
- [ ] `window.PUZZLE_DATA` no longer exists in browser
- [ ] `/api/puzzle` response contains no `answer` field
- [ ] `_devFillAnswer()` works on preview URL for both daily and random
- [ ] Skeleton shimmer displays briefly before clues load
- [ ] Light and dark themes both render skeleton correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)