### PR TITLE
Puzzle archive with replay at /puzzles (#160)

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,6 +398,9 @@
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-feedback"/></svg>
               <span>Feedback</span>
             </button>
+            <a href="/puzzles" class="ui-link">
+              <span>Puzzles</span>
+            </a>
             <button data-theme-toggle class="ui-link">
               <span class="theme-icon" data-theme-icon aria-hidden="true">
                 <svg class="icon-moon" width="24" height="24"><use href="/sprites.svg#icon-moon"/></svg>

--- a/index.html
+++ b/index.html
@@ -424,8 +424,9 @@
               <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer" class="text-link">Jamie</a>
             </span>
             and Dave
+            <br />
+            &copy; 2026 Jamie &amp; Dave
           </div>
-          <p class="footer__copyright">&copy; 2026 Jamie &amp; Dave</p>
           <div class="dev-links hidden" data-dev-links></div>
         </footer>
       </main>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       <!-- ── How to play modal ── -->
       <dialog data-modal aria-labelledby="cw-modal-title">
         <div class="modal__box" data-modal-box>
-          <h2 id="cw-modal-title">How to Play</h2>
+          <h2 id="cw-modal-title">How to play</h2>
           <p class="modal-sub">The clues define a single, 3-digit number from 100–999. New puzzle every day.</p>
           <div class="modal-example">
             <div class="modal-steps">

--- a/index.html
+++ b/index.html
@@ -69,10 +69,10 @@
         </div>
       </dialog>
 
-      <!-- ── How to play modal ── -->
+      <!-- ── Guide modal ── -->
       <dialog data-modal aria-labelledby="cw-modal-title">
         <div class="modal__box" data-modal-box>
-          <h2 id="cw-modal-title">How to play</h2>
+          <h2 id="cw-modal-title">Guide</h2>
           <p class="modal-sub">The clues define a single, 3-digit number from 100–999. New puzzle every day.</p>
           <div class="modal-example">
             <div class="modal-steps">
@@ -392,7 +392,7 @@
           <div class="footer__links" data-foot-links>
             <button data-htp-btn class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-help"/></svg>
-              <span>How to play</span>
+              <span>Guide</span>
             </button>
             <button data-fb-btn class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-feedback"/></svg>

--- a/index.html
+++ b/index.html
@@ -282,9 +282,9 @@
         </p>
 
         <p class="fb-header">
-          <button data-fb-header-btn class="fb-header-link">
+          <button data-fb-header-btn class="text-link text-link--icon text-link--muted">
             <svg width="14" height="14" aria-hidden="true"><use href="/sprites.svg#icon-feedback"/></svg>
-            It's new! Please give feedback
+            <span>It's new! Please give feedback</span>
           </button>
         </p>
 
@@ -382,7 +382,7 @@
 
           <!-- ── Random again ── -->
           <p data-again class="play-again hidden">
-            <a href="/random" class="play-again__link">Play another random puzzle</a>
+            <a href="/random" class="text-link">Play another random puzzle</a>
           </p>
 
         </div>
@@ -390,19 +390,19 @@
         <footer class="footer">
           <div class="swatch-list" data-swatches></div>
           <div class="footer__links" data-foot-links>
-            <button data-htp-btn class="ui-link">
+            <button data-htp-btn class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-help"/></svg>
               <span>How to play</span>
             </button>
-            <button data-fb-btn class="ui-link">
+            <button data-fb-btn class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-feedback"/></svg>
               <span>Feedback</span>
             </button>
-            <a href="/puzzles" class="ui-link">
+            <a href="/puzzles" class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-archive"/></svg>
               <span>Archive</span>
             </a>
-            <button data-theme-toggle class="ui-link">
+            <button data-theme-toggle class="text-link text-link--icon">
               <span class="theme-icon" data-theme-icon aria-hidden="true">
                 <svg class="icon-moon" width="24" height="24"><use href="/sprites.svg#icon-moon"/></svg>
                 <svg class="icon-sun" width="24" height="24"><use href="/sprites.svg#icon-sun"/></svg>
@@ -414,14 +414,14 @@
             An experiment in AI-coding with Claude • Hosted on
             <span class="foot-icon-link">
               <svg width="14" height="14" aria-hidden="true"><use href="/sprites.svg#icon-github"/></svg>
-              <a href="https://github.com/jevawin/clumeral-game" target="_blank" rel="noopener">GitHub</a>
+              <a href="https://github.com/jevawin/clumeral-game" target="_blank" rel="noopener" class="text-link">GitHub</a>
             </span>
             • Made with
             <svg class="footer-heart icon-inline" width="18" height="18" aria-hidden="true"><use href="/sprites.svg#icon-heart"/></svg>
             by
             <span class="foot-icon-link">
               <img src="jamie.webp" alt="Jamie" class="foot-avatar" />
-              <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer">Jamie</a>
+              <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer" class="text-link">Jamie</a>
             </span>
             and Dave
           </div>

--- a/index.html
+++ b/index.html
@@ -399,7 +399,8 @@
               <span>Feedback</span>
             </button>
             <a href="/puzzles" class="ui-link">
-              <span>Puzzles</span>
+              <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-archive"/></svg>
+              <span>Archive</span>
             </a>
             <button data-theme-toggle class="ui-link">
               <span class="theme-icon" data-theme-icon aria-hidden="true">

--- a/public/sprites.svg
+++ b/public/sprites.svg
@@ -70,6 +70,13 @@
     <path d="M12 8h.01" />
   </symbol>
 
+  <!-- Archive -->
+  <symbol id="icon-archive" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+    <path d="M10 12h4" />
+  </symbol>
+
   <!-- Circle X (hollow) -->
   <symbol id="icon-circle-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="10" />

--- a/src/app.ts
+++ b/src/app.ts
@@ -547,7 +547,14 @@ function startDailyPuzzle(date: string, num: number, clues: ClueData[]): void {
 }
 
 function startReplayPuzzle(date: string, num: number, clues: ClueData[]): void {
-  if (dom.plabel) dom.plabel.textContent = `Puzzle #${num} · ${formatDate(date)}`;
+  // Show archived puzzle label above the puzzle number
+  if (dom.plabel) {
+    const label = document.createElement("div");
+    label.className = "card__archive-label";
+    label.innerHTML = `<svg aria-hidden="true"><use href="/sprites.svg#icon-archive"/></svg> Archived puzzle`;
+    dom.plabel.parentElement?.insertBefore(label, dom.plabel);
+    dom.plabel.textContent = `Puzzle #${num} · ${formatDate(date)}`;
+  }
 
   renderClues(clues);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -337,6 +337,27 @@ function renderStats() {
   dom.stats.classList.remove("hidden");
 }
 
+function renderStatsUpTo(upToDate: string) {
+  if (!dom.stats) return;
+  const history = loadHistory().filter(h => h.date <= upToDate);
+  if (history.length === 0) {
+    dom.stats.classList.add("hidden");
+    return;
+  }
+  const avg = (history.reduce((s, h) => s + h.tries, 0) / history.length).toFixed(1);
+  const last5 = history.slice(0, 5);
+  dom.stats.innerHTML = `
+    <p class="stats__heading">Your stats <span class="stats__note">up to ${formatDate(upToDate)}</span></p>
+    <div class="stats__grid">
+      <div class="stats__item"><span class="stats__val">${history.length}</span><span class="stats__lbl">Played</span></div>
+      <div class="stats__item"><span class="stats__val">${avg}</span><span class="stats__lbl">Avg tries</span></div>
+    </div>
+    <p class="stats__last-lbl">Last ${last5.length} game${last5.length !== 1 ? "s" : ""}</p>
+    <div class="stats__bubbles">${last5.map((h) => `<span class="stats__bubble">${h.tries}</span>`).join("")}</div>
+  `;
+  dom.stats.classList.remove("hidden");
+}
+
 // ─── Digit boxes ──────────────────────────────────────────────────────────────
 
 function renderBox(i: number): void {
@@ -445,10 +466,15 @@ function showNextPuzzle() {
   }
 }
 
-function showCompletedState(tries: number): void {
+function showCompletedState(tries: number, replayDate?: string): void {
   const t = tries === 1 ? "1 try" : `${tries} tries`;
   if (dom.feedback) {
-    dom.feedback.innerHTML = `${ICON_CHECK} You already solved today's puzzle in ${t}!`;
+    if (replayDate) {
+      const fDate = formatDate(replayDate);
+      dom.feedback.innerHTML = `${ICON_CHECK} You solved this puzzle in ${t}!<br><span class="feedback__note">Stats up to ${fDate} · <a href="/">Go to latest puzzle</a></span>`;
+    } else {
+      dom.feedback.innerHTML = `${ICON_CHECK} You already solved today's puzzle in ${t}!`;
+    }
     dom.feedback.className = "feedback feedback--correct";
     dom.feedback.classList.remove("hidden");
   }
@@ -460,8 +486,12 @@ function showCompletedState(tries: number): void {
   dom.hint?.classList.add("hidden");
   dom.digits?.classList.add("digit-correct");
   dom.submitWrap?.classList.remove("visible");
-  renderStats();
-  showNextPuzzle();
+  if (replayDate) {
+    renderStatsUpTo(replayDate);
+  } else {
+    renderStats();
+  }
+  if (!replayDate) showNextPuzzle();
 }
 
 function resetPuzzleUI() {
@@ -516,6 +546,31 @@ function startDailyPuzzle(date: string, num: number, clues: ClueData[]): void {
   if (dom.saveCheck) dom.saveCheck.checked = saveScore;
 }
 
+function startReplayPuzzle(date: string, num: number, clues: ClueData[]): void {
+  if (dom.plabel) dom.plabel.textContent = `Puzzle #${num} · ${formatDate(date)}`;
+
+  renderClues(clues);
+
+  // Check if already solved
+  const entry = loadHistory().find(h => h.date === date);
+  if (entry) {
+    gameState = { answer: entry.answer ?? null, guesses: [], solved: true, puzzleNum: num, date };
+    showCompletedState(entry.tries, date);
+    dom.save?.classList.add("hidden");
+    return;
+  }
+
+  gameState = { answer: null, guesses: [], solved: false, puzzleNum: num, date };
+  resetPuzzleUI();
+  track("puzzle_start");
+
+  // Save score for replays
+  const prefs = loadPrefs();
+  saveScore = prefs.saveScore;
+  if (dom.saveCheck) dom.saveCheck.checked = saveScore;
+  dom.again?.classList.add("hidden");
+}
+
 async function handleGuess() {
   if (gameState.solved || submitting) return;
   if (!possibles.every((s) => s.size === 1)) return;
@@ -565,8 +620,8 @@ async function handleGuess() {
       if (gameState.isRandom) {
         dom.again?.classList.remove("hidden");
       } else {
-        if (saveScore) {
-          recordGame(todayLocal(), tries, guess);
+        if (saveScore && gameState.date) {
+          recordGame(gameState.date, tries, guess);
           renderStats();
         }
         showNextPuzzle();
@@ -590,8 +645,18 @@ async function handleGuess() {
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
 async function loadPuzzle() {
-  const isRandom = window.location.pathname === '/random';
-  const endpoint = isRandom ? '/api/puzzle/random' : '/api/puzzle';
+  const path = window.location.pathname;
+  const isRandom = path === '/random';
+  const replayMatch = path.match(/^\/puzzles\/(\d+)$/);
+
+  let endpoint: string;
+  if (isRandom) {
+    endpoint = '/api/puzzle/random';
+  } else if (replayMatch) {
+    endpoint = `/api/puzzle/${replayMatch[1]}`;
+  } else {
+    endpoint = '/api/puzzle';
+  }
 
   try {
     const res = await fetch(endpoint);
@@ -601,6 +666,8 @@ async function loadPuzzle() {
 
     if (isRandom) {
       startRandomPuzzle(data.clues, data.token);
+    } else if (replayMatch) {
+      startReplayPuzzle(data.date, data.puzzleNumber, data.clues);
     } else {
       startDailyPuzzle(data.date, data.puzzleNumber, data.clues);
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -471,7 +471,7 @@ function showCompletedState(tries: number, replayDate?: string): void {
   if (dom.feedback) {
     if (replayDate) {
       const fDate = formatDate(replayDate);
-      dom.feedback.innerHTML = `${ICON_CHECK} You solved this puzzle in ${t}!<br><span class="feedback__note">Stats up to ${fDate} · <a href="/">Go to latest puzzle</a></span>`;
+      dom.feedback.innerHTML = `${ICON_CHECK} You solved this puzzle in ${t}!<br><span class="feedback__note">Stats up to ${fDate} · <a href="/" class="text-link">Go to latest puzzle</a></span>`;
     } else {
       dom.feedback.innerHTML = `${ICON_CHECK} You already solved today's puzzle in ${t}!`;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -85,7 +85,7 @@ function todayLocal() {
 }
 
 function puzzleNumber(dateStr: string): number {
-  const ms = new Date(dateStr + "T00:00:00").getTime() - new Date(EPOCH_DATE + "T00:00:00").getTime();
+  const ms = new Date(dateStr + "T00:00:00Z").getTime() - new Date(EPOCH_DATE + "T00:00:00Z").getTime();
   return Math.max(1, Math.floor(ms / 86400000) + 1);
 }
 

--- a/src/colours.ts
+++ b/src/colours.ts
@@ -71,7 +71,7 @@ function renderDevLinks(): void {
   const addBtn = (label: string, fn: () => void): void => {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'dev-links__btn';
+    btn.className = 'text-link text-link--muted';
     btn.textContent = label;
     btn.addEventListener('click', fn);
     dev.appendChild(btn);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -29,5 +29,5 @@ export function loadHistory(): HistoryEntry[] {
 export function recordGame(dateStr: string, tries: number, answer?: number): void {
   const history = loadHistory().filter((h) => h.date !== dateStr);
   history.unshift({ date: dateStr, tries, ...(answer != null && { answer }) });
-  localStorage.setItem(STORAGE_HISTORY, JSON.stringify(history.slice(0, 60)));
+  localStorage.setItem(STORAGE_HISTORY, JSON.stringify(history));
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1044,10 +1044,6 @@
     & > span:last-child {
       border-block-end: 1px solid var(--acc);
     }
-
-    &:is(a) > span:last-child {
-      border-block-end: none;
-    }
   }
 
   .theme-icon {

--- a/src/style.css
+++ b/src/style.css
@@ -1015,7 +1015,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 1.25rem;
+    gap: 1rem;
     inline-size: 100%;
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1750,37 +1750,39 @@
      overridden with a modifier (--link-color).
      Icon links: use with inline-flex + gap for icon + text. */
   .text-link {
-    display: inline;
+    display: inline-block;
     background: none;
     border: none;
     padding: 0;
     font: inherit;
+    line-height: 1;
     color: var(--link-color, var(--acc));
     cursor: pointer;
     border-block-end: 1px solid currentColor;
-    padding-block-end: 0.125rem;
+    padding-block-end: 0.25rem;
     transition: color 0.4s;
   }
 
-  /* Icon variant: border goes on text span, not the whole element */
+  /* Icon variant: border goes on text span only; icon aligns with text top */
   .text-link--icon {
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.3125rem;
     border-block-end: none;
     padding-block-end: 0;
 
     & svg {
-      width: 0.875rem;
-      height: 0.875rem;
+      width: 1rem;
+      height: 1rem;
       flex-shrink: 0;
       stroke: currentColor;
       transition: stroke 0.4s;
     }
 
     & > span:last-child {
+      line-height: 1;
       border-block-end: 1px solid currentColor;
-      padding-block-end: 0.125rem;
+      padding-block-end: 0.25rem;
     }
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -814,6 +814,17 @@
     color: light-dark(#1a7a3a, #4cc990);
   }
 
+  .feedback__note {
+    display: block;
+    font-size: 1rem;
+    margin-block-start: 0.25rem;
+    color: var(--muted);
+  }
+
+  .feedback__note a {
+    color: var(--acc);
+  }
+
   .feedback--incorrect {
     display: flex;
     align-items: center;
@@ -877,6 +888,12 @@
     color: var(--muted);
     margin-block-end: 0.5rem;
     transition: color 0.4s;
+  }
+
+  .stats__note {
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
   }
 
   .stats__grid {

--- a/src/style.css
+++ b/src/style.css
@@ -1008,7 +1008,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 1rem;
+    gap: 1.25rem;
     inline-size: 100%;
   }
 
@@ -1049,7 +1049,7 @@
 
   .foot-icon-link {
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.25rem;
     vertical-align: middle;
 
@@ -1067,11 +1067,6 @@
     display: block;
   }
 
-  .footer__copyright {
-    margin: 0;
-    color: var(--muted);
-    transition: color 0.4s;
-  }
 
   /* ─── Footer heart ─── */
   @keyframes heart-bounce {

--- a/src/style.css
+++ b/src/style.css
@@ -319,6 +319,28 @@
     transition: color 0.4s;
   }
 
+  .card__archive-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-family: "Inconsolata", monospace;
+    font-size: 1rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    font-weight: 700;
+    padding: 0.5rem 1rem;
+    margin-block-end: 0.75rem;
+    border-radius: 0.25rem;
+    background: var(--text);
+    color: var(--bg);
+
+    & svg {
+      width: 1rem;
+      height: 1rem;
+      flex-shrink: 0;
+    }
+  }
+
   /* ─── Card hint ─── */
   .card__hint {
     font-size: 1rem;
@@ -1008,6 +1030,7 @@
     font-size: 1rem;
     line-height: 1.4;
     cursor: pointer;
+    text-decoration: none;
     transition: color 0.4s;
 
     & svg {

--- a/src/style.css
+++ b/src/style.css
@@ -29,8 +29,6 @@
   :where(a) {
     text-decoration: none;
     color: inherit;
-    border-block-end: 1px solid currentColor;
-    padding-block-end: 0.125rem;
   }
 
   :where(:focus-visible) {
@@ -850,10 +848,6 @@
     color: var(--muted);
   }
 
-  .feedback__note a {
-    color: var(--acc);
-  }
-
   .feedback--incorrect {
     display: flex;
     align-items: center;
@@ -1007,12 +1001,6 @@
     margin-block-start: 0.875rem;
   }
 
-  .play-again__link {
-    color: var(--acc);
-    font-size: 1rem;
-    transition: color 0.4s;
-  }
-
   /* ═══════════════════════════════════════
      Footer links row
      ═══════════════════════════════════════ */
@@ -1024,42 +1012,6 @@
     inline-size: 100%;
   }
 
-  .ui-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3125rem;
-    background: none;
-    border: none;
-    padding: 0;
-    color: var(--acc);
-    font-size: 1rem;
-    line-height: 1.4;
-    cursor: pointer;
-    transition: color 0.4s;
-
-    & svg {
-      width: 0.875rem;
-      height: 0.875rem;
-      flex-shrink: 0;
-      stroke: var(--acc);
-      transition: stroke 0.4s;
-    }
-
-    &:is(button) > span:last-child {
-      border-block-end: 1px solid currentColor;
-      padding-block-end: 0.125rem;
-    }
-
-    &:is(a) {
-      border-block-end: none;
-      padding-block-end: 0;
-    }
-
-    &:is(a) > span:last-child {
-      border-block-end: 1px solid currentColor;
-      padding-block-end: 0.125rem;
-    }
-  }
 
   .theme-icon {
     display: inline-flex;
@@ -1093,10 +1045,6 @@
     color: var(--muted);
     transition: color 0.4s;
 
-    & a {
-      color: var(--acc);
-      transition: color 0.4s;
-    }
   }
 
   .foot-icon-link {
@@ -1195,15 +1143,6 @@
     inline-size: 100%;
   }
 
-  .dev-links__btn {
-    background: none;
-    border: none;
-    border-block-end: 1px solid var(--muted);
-    color: var(--muted);
-    font-size: 1rem;
-    padding: 0;
-    cursor: pointer;
-  }
 
   /* ═══════════════════════════════════════
      How-to-play modal
@@ -1521,27 +1460,6 @@
     margin-block-end: 0.75rem;
   }
 
-  .fb-header-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3125rem;
-    background: none;
-    border: none;
-    border-block-end: 1px solid var(--muted);
-    color: var(--muted);
-    font-family: "DM Sans", system-ui, sans-serif;
-    font-size: 1rem;
-    line-height: 1.4;
-    padding: 0;
-    cursor: pointer;
-    transition: color 0.4s;
-
-    & svg {
-      flex-shrink: 0;
-      stroke: var(--muted);
-      transition: stroke 0.4s;
-    }
-  }
 
   /* ═══════════════════════════════════════
      Feedback modal
@@ -1826,6 +1744,50 @@
     border: 0;
   }
 
+  /* ─── Unified text link ───
+     Works on <a> and <button>. Underline via border on the element
+     itself — no child spans needed. Colour set by the parent or
+     overridden with a modifier (--link-color).
+     Icon links: use with inline-flex + gap for icon + text. */
+  .text-link {
+    display: inline;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: var(--link-color, var(--acc));
+    cursor: pointer;
+    border-block-end: 1px solid currentColor;
+    padding-block-end: 0.125rem;
+    transition: color 0.4s;
+  }
+
+  /* Icon variant: border goes on text span, not the whole element */
+  .text-link--icon {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3125rem;
+    border-block-end: none;
+    padding-block-end: 0;
+
+    & svg {
+      width: 0.875rem;
+      height: 0.875rem;
+      flex-shrink: 0;
+      stroke: currentColor;
+      transition: stroke 0.4s;
+    }
+
+    & > span:last-child {
+      border-block-end: 1px solid currentColor;
+      padding-block-end: 0.125rem;
+    }
+  }
+
+  .text-link--muted {
+    --link-color: var(--muted);
+  }
+
   .skip-link {
     position: absolute;
     inset-inline-start: -999rem;
@@ -1836,7 +1798,6 @@
     color: #fff;
     font-weight: 600;
     border-radius: 0.25rem;
-    border-block-end: none;
 
     &:focus-visible {
       inset-inline-start: 1rem;

--- a/src/style.css
+++ b/src/style.css
@@ -1044,6 +1044,10 @@
     & > span:last-child {
       border-block-end: 1px solid var(--acc);
     }
+
+    &:is(a) > span:last-child {
+      border-block-end: none;
+    }
   }
 
   .theme-icon {

--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,13 @@
     background-color: var(--bg);
   }
 
+  :where(a) {
+    text-decoration: none;
+    color: inherit;
+    border-block-end: 1px solid currentColor;
+    padding-block-end: 0.125rem;
+  }
+
   :where(:focus-visible) {
     outline: 2px solid var(--acc);
     outline-offset: 2px;
@@ -1002,8 +1009,6 @@
 
   .play-again__link {
     color: var(--acc);
-    text-decoration: underline;
-    text-underline-offset: 0.1875rem;
     font-size: 1rem;
     transition: color 0.4s;
   }
@@ -1030,7 +1035,6 @@
     font-size: 1rem;
     line-height: 1.4;
     cursor: pointer;
-    text-decoration: none;
     transition: color 0.4s;
 
     & svg {
@@ -1041,8 +1045,19 @@
       transition: stroke 0.4s;
     }
 
-    & > span:last-child {
-      border-block-end: 1px solid var(--acc);
+    &:is(button) > span:last-child {
+      border-block-end: 1px solid currentColor;
+      padding-block-end: 0.125rem;
+    }
+
+    &:is(a) {
+      border-block-end: none;
+      padding-block-end: 0;
+    }
+
+    &:is(a) > span:last-child {
+      border-block-end: 1px solid currentColor;
+      padding-block-end: 0.125rem;
     }
   }
 
@@ -1079,8 +1094,6 @@
     transition: color 0.4s;
 
     & a {
-      text-decoration: underline;
-      text-underline-offset: 0.1875rem;
       color: var(--acc);
       transition: color 0.4s;
     }
@@ -1823,7 +1836,7 @@
     color: #fff;
     font-weight: 600;
     border-radius: 0.25rem;
-    text-decoration: none;
+    border-block-end: none;
 
     &:focus-visible {
       inset-inline-start: 1rem;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,9 +1,10 @@
 // Worker entry point — serves API routes for puzzle data and guess validation.
 // The answer is never sent to the client.
 
-import { runFilterLoop, makeRng, dateSeedInt, todayLocal, puzzleNumber } from './puzzle.ts';
+import { runFilterLoop, makeRng, dateSeedInt, todayLocal, puzzleNumber, puzzleDate } from './puzzle.ts';
 import { signToken, verifyToken } from './crypto.ts';
 import { getStats, renderDashboard } from './stats.ts';
+import { renderPuzzlesPage } from './puzzles.ts';
 
 interface Env {
   ASSETS: { fetch: (req: Request) => Promise<Response> };
@@ -126,6 +127,17 @@ export default {
       return handleGuess(request, env);
     }
 
+    // GET /api/puzzle/:num — return clues for a specific puzzle number (no answer)
+    const puzzleByNum = url.pathname.match(/^\/api\/puzzle\/(\d+)$/);
+    if (request.method === 'GET' && puzzleByNum) {
+      const num = parseInt(puzzleByNum[1], 10);
+      if (num < 1) return json({ error: 'Invalid puzzle number' }, 400);
+      const date = puzzleDate(num);
+      if (date > todayLocal()) return json({ error: 'Puzzle not available yet' }, 400);
+      const puzzle = await getDailyPuzzle(env, date);
+      return json({ date, puzzleNumber: num, clues: puzzle.clues });
+    }
+
     // Dev-only: return the answer for the current puzzle (blocked on production domain)
     if (request.method === 'GET' && url.pathname === '/api/dev/answer') {
       if (url.hostname === 'clumeral.com') return new Response('Not found', { status: 404 });
@@ -201,6 +213,39 @@ export default {
           headers: { 'Content-Type': 'text/plain' },
         });
       }
+    }
+
+    // ── Puzzles ──
+
+    // GET /puzzles — Worker-rendered puzzle history page
+    if (request.method === 'GET' && url.pathname === '/puzzles') {
+      const today = todayLocal();
+      const todayNum = puzzleNumber(today);
+      const keys = await env.PUZZLES.list();
+      const puzzles = await Promise.all(
+        keys.keys
+          .filter(k => /^\d{4}-\d{2}-\d{2}$/.test(k.name) && k.name <= today)
+          .map(async k => {
+            const p = await env.PUZZLES.get<StoredPuzzle>(k.name, 'json');
+            return p ? { num: p.puzzleNumber, date: k.name, clues: p.clues.length } : null;
+          })
+      );
+      // Include today if not yet in KV
+      const dates = new Set(keys.keys.map(k => k.name));
+      if (!dates.has(today)) {
+        const p = await getDailyPuzzle(env, today);
+        puzzles.push({ num: todayNum, date: today, clues: p.clues.length });
+      }
+      const valid = puzzles.filter((p): p is NonNullable<typeof p> => p !== null);
+      const html = renderPuzzlesPage(valid);
+      return new Response(html, {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    // GET /puzzles/:num — serve game HTML for replay
+    if (request.method === 'GET' && /^\/puzzles\/\d+$/.test(url.pathname)) {
+      return env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
     }
 
     // ── Static pages ──

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -227,7 +227,7 @@ export default {
           .filter(k => /^\d{4}-\d{2}-\d{2}$/.test(k.name) && k.name <= today)
           .map(async k => {
             const p = await env.PUZZLES.get<StoredPuzzle>(k.name, 'json');
-            return p ? { num: p.puzzleNumber, date: k.name, clues: p.clues.length } : null;
+            return p ? { num: puzzleNumber(k.name), date: k.name, clues: p.clues.length } : null;
           })
       );
       // Include today if not yet in KV

--- a/src/worker/puzzle.ts
+++ b/src/worker/puzzle.ts
@@ -196,3 +196,9 @@ export function puzzleNumber(dateStr: string): number {
   const ms = new Date(dateStr + 'T00:00:00').getTime() - new Date(EPOCH_DATE + 'T00:00:00').getTime();
   return Math.max(1, Math.floor(ms / 86400000) + 1);
 }
+
+export function puzzleDate(num: number): string {
+  const epoch = new Date(EPOCH_DATE + 'T00:00:00');
+  const d = new Date(epoch.getTime() + (num - 1) * 86400000);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/src/worker/puzzle.ts
+++ b/src/worker/puzzle.ts
@@ -193,12 +193,12 @@ export function dateSeedInt(dateStr: string): number {
 const EPOCH_DATE = '2026-03-08';
 
 export function puzzleNumber(dateStr: string): number {
-  const ms = new Date(dateStr + 'T00:00:00').getTime() - new Date(EPOCH_DATE + 'T00:00:00').getTime();
+  const ms = new Date(dateStr + 'T00:00:00Z').getTime() - new Date(EPOCH_DATE + 'T00:00:00Z').getTime();
   return Math.max(1, Math.floor(ms / 86400000) + 1);
 }
 
 export function puzzleDate(num: number): string {
-  const epoch = new Date(EPOCH_DATE + 'T00:00:00');
+  const epoch = new Date(EPOCH_DATE + 'T00:00:00Z');
   const d = new Date(epoch.getTime() + (num - 1) * 86400000);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 }

--- a/src/worker/puzzles.ts
+++ b/src/worker/puzzles.ts
@@ -1,0 +1,216 @@
+// Worker-rendered puzzle history page at /puzzles
+
+interface PuzzleSummary {
+  num: number;
+  date: string;
+  clues: number;
+}
+
+function fmtDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  const day = d.getDate();
+  const mon = d.toLocaleDateString('en-GB', { month: 'short' });
+  const yr = d.getFullYear();
+  const now = new Date().getFullYear();
+  return yr !== now ? `${day} ${mon}, ${String(yr).slice(2)}` : `${day} ${mon}`;
+}
+
+export function renderPuzzlesPage(puzzles: PuzzleSummary[]): string {
+  const rows = puzzles
+    .sort((a, b) => b.num - a.num)
+    .map(p => `["${p.date}",${p.num},${p.clues}]`)
+    .join(',');
+
+  const tableRows = puzzles
+    .sort((a, b) => b.num - a.num)
+    .map(p =>
+      `<tr class="row" data-num="${p.num}" data-date="${p.date}" data-clues="${p.clues}">
+        <td><a href="/puzzles/${p.num}">${p.num}</a></td>
+        <td>${fmtDate(p.date)}</td>
+        <td class="num-col">${p.clues}</td>
+        <td class="num-col" data-tries></td>
+      </tr>`
+    )
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Clumeral — Puzzles</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Inconsolata:wght@500;700&display=swap" rel="stylesheet">
+<script>
+  (function () {
+    var t = localStorage.getItem("dlng_theme");
+    if (!t) t = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    document.documentElement.classList.add(t);
+  })();
+</script>
+<style>
+  :root { color-scheme: light dark; --acc: light-dark(#0a850a, #1ead52); }
+  :root.dark { color-scheme: dark; }
+  :root.light { color-scheme: light; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: "DM Sans", system-ui, sans-serif;
+    background: light-dark(#f5edd8, #262624);
+    color: light-dark(#262624, #f6f0e8);
+    padding: 1.5rem 1rem;
+    max-width: 32rem;
+    margin: 0 auto;
+  }
+  a { color: var(--acc); }
+  .back { font-size: 1rem; margin-block-end: 1rem; display: inline-block; }
+  h1 { font-size: 1.5rem; margin-block-end: 0.25rem; }
+  .subtitle {
+    font-size: 1rem;
+    color: light-dark(rgba(38,38,36,0.7), rgba(246,240,232,0.6));
+    margin-block-end: 1.5rem;
+  }
+  table { width: 100%; border-collapse: collapse; }
+  th, td {
+    padding: 0.5rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid light-dark(rgba(38,38,36,0.1), rgba(255,253,247,0.08));
+  }
+  th {
+    font-size: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: light-dark(rgba(38,38,36,0.5), rgba(246,240,232,0.4));
+    border-bottom: 2px solid light-dark(rgba(38,38,36,0.15), rgba(255,253,247,0.12));
+    white-space: nowrap;
+    user-select: none;
+  }
+  th.sortable { cursor: pointer; }
+  th.sortable .sort-label {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    text-decoration-thickness: 1.5px;
+    text-decoration-color: light-dark(rgba(38,38,36,0.3), rgba(246,240,232,0.3));
+  }
+  th.sortable:hover .sort-label {
+    text-decoration-color: light-dark(rgba(38,38,36,0.6), rgba(246,240,232,0.6));
+  }
+  .sort-icon {
+    display: none;
+    width: 12px;
+    height: 12px;
+    vertical-align: -1px;
+    margin-inline-start: 0.2rem;
+    transition: transform 0.15s;
+  }
+  th.sorted .sort-icon { display: inline-block; }
+  th.sorted.asc .sort-icon { transform: rotate(180deg); }
+  td:first-child {
+    font-family: "Inconsolata", monospace;
+    font-weight: 700;
+    width: 3rem;
+  }
+  td:first-child a {
+    color: var(--acc);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+  }
+  .num-col { font-family: "Inconsolata", monospace; font-weight: 600; text-align: right; }
+  th.num-header { text-align: right; }
+  .play-link {
+    font-family: "DM Sans", system-ui, sans-serif;
+    font-weight: 600;
+    font-size: 1rem;
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+  }
+  tr.row { cursor: pointer; transition: background 0.1s; }
+  tr.row:hover { background: light-dark(rgba(10,133,10,0.04), rgba(30,173,82,0.06)); }
+  tr.row:active { background: light-dark(rgba(10,133,10,0.08), rgba(30,173,82,0.1)); }
+</style>
+</head>
+<body>
+  <a href="/" class="back">&larr; Back to today's puzzle</a>
+  <h1>Every Clumeral ever.</h1>
+  <p class="subtitle">Tap to replay a puzzle. Tap a column to sort by it.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th class="sortable sorted desc" data-sort="date" data-type="num"><span class="sort-label">Date</span> <svg class="sort-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></th>
+        <th class="sortable num-header" data-sort="clues" data-type="num"><span class="sort-label">Clues</span> <svg class="sort-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></th>
+        <th class="num-header">Tries</th>
+      </tr>
+    </thead>
+    <tbody id="tbody">
+      ${tableRows}
+    </tbody>
+  </table>
+
+<script>
+// Populate tries column from localStorage
+(function() {
+  var history = [];
+  try { history = JSON.parse(localStorage.getItem("dlng_history") || "[]"); } catch(e) {}
+  var byDate = {};
+  for (var i = 0; i < history.length; i++) byDate[history[i].date] = history[i].tries;
+
+  var rows = document.querySelectorAll("tr.row");
+  for (var r = 0; r < rows.length; r++) {
+    var date = rows[r].getAttribute("data-date");
+    var num = rows[r].getAttribute("data-num");
+    var cell = rows[r].querySelector("[data-tries]");
+    if (byDate[date] != null) {
+      cell.textContent = byDate[date];
+    } else {
+      cell.innerHTML = '<a href="/puzzles/' + num + '" class="play-link">Play</a>';
+    }
+  }
+})();
+
+// Sorting
+var sortKey = "date";
+var sortAsc = false;
+var tbody = document.getElementById("tbody");
+
+function sortRows() {
+  var rows = Array.from(tbody.querySelectorAll("tr.row"));
+  rows.sort(function(a, b) {
+    var va, vb;
+    if (sortKey === "date") {
+      va = parseInt(a.getAttribute("data-num"));
+      vb = parseInt(b.getAttribute("data-num"));
+    } else {
+      va = parseInt(a.getAttribute("data-" + sortKey));
+      vb = parseInt(b.getAttribute("data-" + sortKey));
+    }
+    return sortAsc ? va - vb : vb - va;
+  });
+  for (var i = 0; i < rows.length; i++) tbody.appendChild(rows[i]);
+}
+
+document.querySelectorAll("th.sortable").forEach(function(th) {
+  th.addEventListener("click", function() {
+    var key = th.getAttribute("data-sort");
+    if (sortKey === key) { sortAsc = !sortAsc; }
+    else { sortKey = key; sortAsc = false; }
+    document.querySelectorAll("th.sortable").forEach(function(h) {
+      h.classList.remove("sorted", "asc", "desc");
+    });
+    th.classList.add("sorted", sortAsc ? "asc" : "desc");
+    sortRows();
+  });
+});
+
+// Row click navigation
+document.querySelectorAll("tr.row").forEach(function(row) {
+  row.addEventListener("click", function(e) {
+    if (e.target.tagName === "A") return;
+    location.href = "/puzzles/" + row.getAttribute("data-num");
+  });
+});
+</script>
+</body>
+</html>`;
+}

--- a/src/worker/puzzles.ts
+++ b/src/worker/puzzles.ts
@@ -61,7 +61,7 @@ export function renderPuzzlesPage(puzzles: PuzzleSummary[]): string {
     max-width: 32rem;
     margin: 0 auto;
   }
-  a { color: var(--acc); }
+  a { color: var(--acc); text-decoration: none; border-block-end: 1px solid currentColor; padding-block-end: 0.125rem; }
   .back { font-size: 1rem; margin-block-end: 1rem; display: inline-block; }
   h1 { font-size: 1.5rem; margin-block-end: 0.25rem; }
   .subtitle {
@@ -112,8 +112,6 @@ export function renderPuzzlesPage(puzzles: PuzzleSummary[]): string {
   }
   td:first-child a {
     color: var(--acc);
-    text-decoration: underline;
-    text-underline-offset: 0.15em;
   }
   .num-col { font-family: "Inconsolata", monospace; font-weight: 600; text-align: right; }
   th.num-header { text-align: right; }
@@ -121,8 +119,6 @@ export function renderPuzzlesPage(puzzles: PuzzleSummary[]): string {
     font-family: "DM Sans", system-ui, sans-serif;
     font-weight: 600;
     font-size: 1rem;
-    text-decoration: underline;
-    text-underline-offset: 0.15em;
   }
   tr.row { cursor: pointer; transition: background 0.1s; }
   tr.row:hover { background: light-dark(rgba(10,133,10,0.04), rgba(30,173,82,0.06)); }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
   "main": "./src/worker/index.ts",
   "assets": {
     "binding": "ASSETS",
-    "run_worker_first": ["/", "/index.html", "/random", "/api/*", "/stats"]
+    "run_worker_first": ["/", "/index.html", "/random", "/puzzles", "/puzzles/*", "/api/*", "/stats"]
   },
   "analytics_engine_datasets": [
     {


### PR DESCRIPTION
## Summary
- New \`/puzzles\` page listing all historical puzzles — sortable by date or clue count
- Replay any past puzzle at \`/puzzles/:num\` with server-side validation
- Already-solved puzzles show completion state with stats up to that date
- Unified all link styling into \`.text-link\` class (removed ~50 lines of duplicated CSS)
- Renamed "How to play" to "Guide" for one-word footer consistency
- Added archive icon, fixed DST-induced off-by-one in puzzle numbers
- Removed 60-entry history cap from localStorage
- Created follow-up issues: #161 (difficulty stats), #162 (login), #163 (streaks), #165 (refactor)

## Test plan
- [ ] Archive page loads and lists all puzzles
- [ ] Sort by Date and Clues works (asc/desc toggle)
- [ ] Play links go to the correct puzzle
- [ ] Replaying an unplayed puzzle works and saves score
- [ ] Replaying a solved puzzle shows stats up to that date + "Go to latest puzzle" link
- [ ] Dev helper (\`_devFillAnswer()\`) works in replay mode
- [ ] Footer link layout works on mobile (no wrapping)
- [ ] All link underlines look consistent
- [ ] Light and dark themes both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)