### PR TITLE
Footer icon link alignment fix

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1049,9 +1049,8 @@
 
   .foot-icon-link {
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.25rem;
-    vertical-align: middle;
 
     & svg {
       color: var(--text);

--- a/src/style.css
+++ b/src/style.css
@@ -1049,7 +1049,7 @@
 
   .foot-icon-link {
     display: inline-flex;
-    align-items: flex-start;
+    align-items: baseline;
     gap: 0.25rem;
 
     & svg {

--- a/src/style.css
+++ b/src/style.css
@@ -1049,7 +1049,7 @@
 
   .foot-icon-link {
     display: inline-flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 0.25rem;
     vertical-align: middle;
 


### PR DESCRIPTION
## Summary
- Align GitHub/Jamie icons to the text baseline in footer body

🤖 Generated with [Claude Code](https://claude.com/claude-code)