### PR TITLE
Archive replay fixes (#160)

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
     <meta name="twitter:description" content="Work out the number from 100–999. New puzzle every day." />
     <meta name="twitter:image" content="https://clumeral.com/og-image.png" />
 
-    <link rel="icon" type="image/png" href="icons/lime/dark/icon-192.png" />
-    <link rel="manifest" href="manifest.json" />
-    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="/icons/lime/dark/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="stylesheet" href="/src/style.css" />
     <script>
       (function () {
@@ -420,7 +420,7 @@
             <svg class="footer-heart icon-inline" width="18" height="18" aria-hidden="true"><use href="/sprites.svg#icon-heart"/></svg>
             by
             <span class="foot-icon-link">
-              <img src="jamie.webp" alt="Jamie" class="foot-avatar" />
+              <img src="/jamie.webp" alt="Jamie" class="foot-avatar" />
               <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer" class="text-link">Jamie</a>
             </span>
             and Dave

--- a/src/app.ts
+++ b/src/app.ts
@@ -340,20 +340,23 @@ function renderStats() {
 function renderStatsUpTo(upToDate: string) {
   if (!dom.stats) return;
   const history = loadHistory().filter(h => h.date <= upToDate);
+  const fDate = formatDate(upToDate);
   if (history.length === 0) {
-    dom.stats.classList.add("hidden");
+    dom.stats.innerHTML = `<p class="stats__latest"><a href="/" class="text-link">Go to latest puzzle</a></p>`;
+    dom.stats.classList.remove("hidden");
     return;
   }
   const avg = (history.reduce((s, h) => s + h.tries, 0) / history.length).toFixed(1);
   const last5 = history.slice(0, 5);
   dom.stats.innerHTML = `
-    <p class="stats__heading">Your stats <span class="stats__note">up to ${formatDate(upToDate)}</span></p>
+    <p class="stats__heading">Your stats (to ${fDate})</p>
     <div class="stats__grid">
       <div class="stats__item"><span class="stats__val">${history.length}</span><span class="stats__lbl">Played</span></div>
       <div class="stats__item"><span class="stats__val">${avg}</span><span class="stats__lbl">Avg tries</span></div>
     </div>
     <p class="stats__last-lbl">Last ${last5.length} game${last5.length !== 1 ? "s" : ""}</p>
     <div class="stats__bubbles">${last5.map((h) => `<span class="stats__bubble">${h.tries}</span>`).join("")}</div>
+    <p class="stats__latest"><a href="/" class="text-link">Go to latest puzzle</a></p>
   `;
   dom.stats.classList.remove("hidden");
 }
@@ -469,12 +472,10 @@ function showNextPuzzle() {
 function showCompletedState(tries: number, replayDate?: string): void {
   const t = tries === 1 ? "1 try" : `${tries} tries`;
   if (dom.feedback) {
-    if (replayDate) {
-      const fDate = formatDate(replayDate);
-      dom.feedback.innerHTML = `${ICON_CHECK} You solved this puzzle in ${t}!<br><span class="feedback__note">Stats up to ${fDate} · <a href="/" class="text-link">Go to latest puzzle</a></span>`;
-    } else {
-      dom.feedback.innerHTML = `${ICON_CHECK} You already solved today's puzzle in ${t}!`;
-    }
+    const message = replayDate
+      ? `You solved this puzzle in ${t}!`
+      : `You already solved today's puzzle in ${t}!`;
+    dom.feedback.innerHTML = `${ICON_CHECK} ${message}`;
     dom.feedback.className = "feedback feedback--correct";
     dom.feedback.classList.remove("hidden");
   }
@@ -490,8 +491,8 @@ function showCompletedState(tries: number, replayDate?: string): void {
     renderStatsUpTo(replayDate);
   } else {
     renderStats();
+    showNextPuzzle();
   }
-  if (!replayDate) showNextPuzzle();
 }
 
 function resetPuzzleUI() {
@@ -546,7 +547,7 @@ function startDailyPuzzle(date: string, num: number, clues: ClueData[]): void {
   if (dom.saveCheck) dom.saveCheck.checked = saveScore;
 }
 
-function startReplayPuzzle(date: string, num: number, clues: ClueData[]): void {
+async function startReplayPuzzle(date: string, num: number, clues: ClueData[]): Promise<void> {
   // Show archived puzzle label above the puzzle number
   if (dom.plabel) {
     const label = document.createElement("div");
@@ -561,7 +562,18 @@ function startReplayPuzzle(date: string, num: number, clues: ClueData[]): void {
   // Check if already solved
   const entry = loadHistory().find(h => h.date === date);
   if (entry) {
-    gameState = { answer: entry.answer ?? null, guesses: [], solved: true, puzzleNum: num, date };
+    let answer = entry.answer ?? null;
+    // Old history entries may not have the answer stored — fetch it
+    if (answer == null) {
+      try {
+        const res = await fetch(`/api/puzzle/${num}/solution`);
+        if (res.ok) {
+          const data = await res.json() as { answer: number };
+          answer = data.answer;
+        }
+      } catch { /* leave as null */ }
+    }
+    gameState = { answer, guesses: [], solved: true, puzzleNum: num, date };
     showCompletedState(entry.tries, date);
     dom.save?.classList.add("hidden");
     return;

--- a/src/style.css
+++ b/src/style.css
@@ -841,13 +841,6 @@
     color: light-dark(#1a7a3a, #4cc990);
   }
 
-  .feedback__note {
-    display: block;
-    font-size: 1rem;
-    margin-block-start: 0.25rem;
-    color: var(--muted);
-  }
-
   .feedback--incorrect {
     display: flex;
     align-items: center;
@@ -913,12 +906,6 @@
     transition: color 0.4s;
   }
 
-  .stats__note {
-    font-weight: 400;
-    text-transform: none;
-    letter-spacing: 0;
-  }
-
   .stats__grid {
     display: flex;
     gap: 1.5rem;
@@ -956,6 +943,11 @@
   .stats__bubbles {
     display: flex;
     gap: 0.375rem;
+  }
+
+  .stats__latest {
+    margin-block-start: 1rem;
+    font-size: 1rem;
   }
 
   .stats__bubble {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -138,6 +138,19 @@ export default {
       return json({ date, puzzleNumber: num, clues: puzzle.clues });
     }
 
+    // GET /api/puzzle/:num/solution — return answer for a PAST puzzle (not today)
+    // Used to reveal the answer in the already-solved state when the client's
+    // history entry predates answer-saving. Today's puzzle is protected.
+    const solutionByNum = url.pathname.match(/^\/api\/puzzle\/(\d+)\/solution$/);
+    if (request.method === 'GET' && solutionByNum) {
+      const num = parseInt(solutionByNum[1], 10);
+      if (num < 1) return json({ error: 'Invalid puzzle number' }, 400);
+      const date = puzzleDate(num);
+      if (date >= todayLocal()) return json({ error: 'Solution not available' }, 403);
+      const puzzle = await getDailyPuzzle(env, date);
+      return json({ answer: puzzle.answer });
+    }
+
     // Dev-only: return the answer for the current puzzle (blocked on production domain)
     if (request.method === 'GET' && url.pathname === '/api/dev/answer') {
       if (url.hostname === 'clumeral.com') return new Response('Not found', { status: 404 });


### PR DESCRIPTION
## Summary
- Absolute paths for static assets so they load on \`/puzzles/:num\`
- New \`/api/puzzle/:num/solution\` endpoint for past puzzles (fills in missing answers for old history entries)
- Reworked already-solved feedback layout — stats heading includes date, Go to latest link below stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)