### PR TITLE
Ship: server-side puzzle logic + archive with replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,34 @@ Remote branches are auto-deleted by GitHub on PR merge. After merging, run `git 
 4. **PR to main** — once staging has all approved branches, Claude creates a PR from `staging` → `main` and provides the staging preview URL and PR link
 5. **Final review** — the user tests staging with all branches combined
 6. **Ship** — the user merges the PR to `main` from GitHub
+7. **Sync staging back** — immediately after the main merge, Claude opens a sync PR to bring staging back in line with main (see "Post-merge sync" below). Skipping this step will cause divergence and conflicts on the next `staging → main` PR.
 
 **Key rules:**
 - **Never merge to `main`** — the user does this from GitHub. No exceptions unless the user explicitly grants override permission with a stated reason.
 - **Merge to `staging` only after user approval** — Claude can squash-merge via `gh pr merge --squash` once the user confirms the branch
 - **Never run `wrangler deploy` or `npm run deploy`** — deployment is automatic via Cloudflare Git integration on merge to `main`
+
+### Post-merge sync (critical)
+
+**Why it matters:** `main` uses squash merges, so every `staging → main` merge creates a new commit on `main` with a hash that doesn't exist in `staging`'s history. Without syncing `staging` back, the two branches drift. On the next release, `git merge-base staging main` points to a stale ancestor, and any change that touched the same lines in both branches becomes a three-way merge conflict — even when the resolution is obvious.
+
+**What to do after `staging → main` is merged on GitHub:**
+
+The user must update `staging` to include `main`'s new commits. The cleanest approach — because `staging` is protected (no merge commits, no force-push from Claude) — is to run this locally:
+
+```bash
+git checkout staging
+git pull origin staging
+git fetch origin main
+git reset --hard origin/main
+git push --force-with-lease origin staging
+```
+
+This requires the user to temporarily allow force-push on `staging`, or to be a branch admin. If that's not acceptable, the alternative is for the user to open a PR from a fresh branch that takes main's state and squash-merge it into staging — messier but works within the protection rules.
+
+**If this step is skipped** and divergence occurs, the next `staging → main` PR will likely conflict. The recovery path is to create a `release/*` branch directly off `main`, copy `staging`'s working tree onto it as a single commit (`git checkout staging -- .`), and PR that branch to main instead of the staging branch directly. The current branch state is preserved but staging still needs re-syncing afterwards.
+
+### Cloudflare preview URLs
 
 ### Cloudflare preview URLs
 

--- a/docs/SELF-REVIEW.md
+++ b/docs/SELF-REVIEW.md
@@ -50,6 +50,6 @@ This is a **living document** — when a review catches something the self-revie
 
 ## Worker / service worker
 
-- Does the Worker still inject `window.PUZZLE_DATA` correctly for both `/` and `/random` routes?
+- Do API responses from the Worker avoid sending the answer to the client?
 - Does `sw.js` cache versioning align with any changed assets?
-- No accidental caching of puzzle data (daily puzzles must be fresh)
+- No accidental caching of API responses (puzzle data and guess validation must be fresh)

--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
     <meta name="twitter:description" content="Work out the number from 100–999. New puzzle every day." />
     <meta name="twitter:image" content="https://clumeral.com/og-image.png" />
 
-    <link rel="icon" type="image/png" href="icons/lime/dark/icon-192.png" />
-    <link rel="manifest" href="manifest.json" />
-    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="/icons/lime/dark/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="stylesheet" href="/src/style.css" />
     <script>
       (function () {
@@ -69,10 +69,10 @@
         </div>
       </dialog>
 
-      <!-- ── How to play modal ── -->
+      <!-- ── Guide modal ── -->
       <dialog data-modal aria-labelledby="cw-modal-title">
         <div class="modal__box" data-modal-box>
-          <h2 id="cw-modal-title">How to Play</h2>
+          <h2 id="cw-modal-title">Guide</h2>
           <p class="modal-sub">The clues define a single, 3-digit number from 100–999. New puzzle every day.</p>
           <div class="modal-example">
             <div class="modal-steps">
@@ -282,9 +282,9 @@
         </p>
 
         <p class="fb-header">
-          <button data-fb-header-btn class="fb-header-link">
+          <button data-fb-header-btn class="text-link text-link--icon text-link--muted">
             <svg width="14" height="14" aria-hidden="true"><use href="/sprites.svg#icon-feedback"/></svg>
-            It's new! Please give feedback
+            <span>It's new! Please give feedback</span>
           </button>
         </p>
 
@@ -292,85 +292,40 @@
         <div id="puzzle" class="card" data-card>
           <div class="card__label" data-plabel>Puzzle #7 · 14 March 2026</div>
 
-          <div class="clue-list" role="list" aria-label="Puzzle clues">
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">CUBE</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The third digit is</div>
-                <div class="clue__line2">a cube number</div>
+          <div class="clue-list" role="list" aria-label="Puzzle clues" aria-busy="true">
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">RANGE</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The range of all three digits is</div>
-                <div class="clue__line2">= 5</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">MEAN</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The mean of all three digits is</div>
-                <div class="clue__line2">
-                  ≠ 2.
-                  <span style="display: inline-block; position: relative">
-                    3
-                    <span style="position: absolute; left: 50%; top: -0.55em; transform: translateX(-50%); font-size: 1.4rem; line-height: 1">·</span>
-                  </span>
-                </div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">SUM</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The sum of the 1st and 3rd digits is</div>
-                <div class="clue__line2">≤ 2</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
-
-            <div class="clue" role="listitem">
-              <div class="clue__tag-cell">
-                <span class="clue__tag">PROD</span>
-                <div class="clue__digits" aria-hidden="true">
-                  <div class="clue__digit"></div>
-                  <div class="clue__digit lit"></div>
-                  <div class="clue__digit lit"></div>
-                </div>
-              </div>
-              <div class="clue__lines">
-                <div class="clue__line1">The product of the 2nd and 3rd digits is</div>
-                <div class="clue__line2">≤ 0</div>
+            <div class="clue-skeleton" aria-hidden="true">
+              <div class="clue-skeleton__tag"></div>
+              <div class="clue-skeleton__lines">
+                <div class="clue-skeleton__line clue-skeleton__line--long"></div>
+                <div class="clue-skeleton__line clue-skeleton__line--short"></div>
               </div>
             </div>
           </div>
@@ -427,7 +382,7 @@
 
           <!-- ── Random again ── -->
           <p data-again class="play-again hidden">
-            <a href="/random" class="play-again__link">Play another random puzzle</a>
+            <a href="/random" class="text-link">Play another random puzzle</a>
           </p>
 
         </div>
@@ -435,15 +390,19 @@
         <footer class="footer">
           <div class="swatch-list" data-swatches></div>
           <div class="footer__links" data-foot-links>
-            <button data-htp-btn class="ui-link">
+            <button data-htp-btn class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-help"/></svg>
-              <span>How to play</span>
+              <span>Guide</span>
             </button>
-            <button data-fb-btn class="ui-link">
+            <button data-fb-btn class="text-link text-link--icon">
               <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-feedback"/></svg>
               <span>Feedback</span>
             </button>
-            <button data-theme-toggle class="ui-link">
+            <a href="/puzzles" class="text-link text-link--icon">
+              <svg width="24" height="24" aria-hidden="true"><use href="/sprites.svg#icon-archive"/></svg>
+              <span>Archive</span>
+            </a>
+            <button data-theme-toggle class="text-link text-link--icon">
               <span class="theme-icon" data-theme-icon aria-hidden="true">
                 <svg class="icon-moon" width="24" height="24"><use href="/sprites.svg#icon-moon"/></svg>
                 <svg class="icon-sun" width="24" height="24"><use href="/sprites.svg#icon-sun"/></svg>
@@ -452,19 +411,21 @@
             </button>
           </div>
           <div class="footer__body" data-foot-body>
-            An experiment in AI-coding with Claude • Hosted on
+            An experiment in AI-coding with Claude • It's on
             <span class="foot-icon-link">
               <svg width="14" height="14" aria-hidden="true"><use href="/sprites.svg#icon-github"/></svg>
-              <a href="https://github.com/jevawin/clumeral-game" target="_blank" rel="noopener">GitHub</a>
+              <a href="https://github.com/jevawin/clumeral-game" target="_blank" rel="noopener" class="text-link">GitHub</a>
             </span>
             • Made with
             <svg class="footer-heart icon-inline" width="18" height="18" aria-hidden="true"><use href="/sprites.svg#icon-heart"/></svg>
             by
             <span class="foot-icon-link">
-              <img src="jamie.webp" alt="Jamie" class="foot-avatar" />
-              <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer">Jamie</a>
+              <img src="/jamie.webp" alt="Jamie" class="foot-avatar" />
+              <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer" class="text-link">Jamie</a>
             </span>
             and Dave
+            <br />
+            &copy; 2026 Jamie &amp; Dave
           </div>
           <p class="footer__copyright">&copy; 2026 Jamie &amp; Dave</p>
           <div class="dev-links hidden" data-dev-links></div>

--- a/public/sprites.svg
+++ b/public/sprites.svg
@@ -70,6 +70,13 @@
     <path d="M12 8h.01" />
   </symbol>
 
+  <!-- Archive -->
+  <symbol id="icon-archive" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+    <path d="M10 12h4" />
+  </symbol>
+
   <!-- Circle X (hollow) -->
   <symbol id="icon-circle-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="10" />

--- a/public/sw.js
+++ b/public/sw.js
@@ -34,7 +34,7 @@ self.addEventListener('activate', (e) => {
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
 
-  // Network-first for navigation (gets fresh puzzle data injected by Worker)
+  // Network-first for navigation (gets fresh HTML from Worker)
   if (e.request.mode === 'navigate') {
     e.respondWith(
       fetch(e.request)
@@ -45,6 +45,11 @@ self.addEventListener('fetch', (e) => {
         })
         .catch(() => caches.match(e.request))
     );
+    return;
+  }
+
+  // Network-only for API routes (never cache puzzle data or guess responses)
+  if (url.origin === self.location.origin && url.pathname.startsWith('/api/')) {
     return;
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 // Clumeral — app.ts
-// Puzzle data is injected by the Worker as window.PUZZLE_DATA.
+// Puzzle data is fetched from the API. The answer never reaches the client.
 
 import type { GameState, ClueData } from './types.ts';
 import { launchConfetti } from './confetti.ts';
@@ -64,6 +64,7 @@ const dom = {
 
 let gameState: GameState = { answer: null, guesses: [], solved: false };
 let saveScore = true;
+let submitting = false; // guard against double-submit during API call
 
 function initPossibles(): Set<number>[] {
   return [
@@ -84,7 +85,7 @@ function todayLocal() {
 }
 
 function puzzleNumber(dateStr: string): number {
-  const ms = new Date(dateStr + "T00:00:00").getTime() - new Date(EPOCH_DATE + "T00:00:00").getTime();
+  const ms = new Date(dateStr + "T00:00:00Z").getTime() - new Date(EPOCH_DATE + "T00:00:00Z").getTime();
   return Math.max(1, Math.floor(ms / 86400000) + 1);
 }
 
@@ -202,6 +203,7 @@ function closeTagTip(): void {
 
 function renderClues(clues: ClueData[]): void {
   if (!dom.clueList) return;
+  dom.clueList.removeAttribute("aria-busy");
   dom.clueList.innerHTML = "";
   for (const { propKey, label, operator, value } of clues) {
     const tag = getClueTag(propKey);
@@ -281,6 +283,12 @@ function renderFeedback(type: string | null, answer?: number): void {
       dom.feedback.className = "feedback feedback--incorrect";
       dom.feedback.classList.remove("hidden");
     }
+  } else if (type === "error") {
+    if (dom.feedback) {
+      dom.feedback.innerHTML = `${ICON_CROSS} Something went wrong — please try again.`;
+      dom.feedback.className = "feedback feedback--incorrect";
+      dom.feedback.classList.remove("hidden");
+    }
   } else {
     if (dom.hint) {
       dom.hint.textContent = "Tap a box to eliminate possible numbers.";
@@ -325,6 +333,30 @@ function renderStats() {
     </div>
     <p class="stats__last-lbl">Last ${last5.length} game${last5.length !== 1 ? "s" : ""}</p>
     <div class="stats__bubbles">${last5.map((h) => `<span class="stats__bubble">${h.tries}</span>`).join("")}</div>
+  `;
+  dom.stats.classList.remove("hidden");
+}
+
+function renderStatsUpTo(upToDate: string) {
+  if (!dom.stats) return;
+  const history = loadHistory().filter(h => h.date <= upToDate);
+  const fDate = formatDate(upToDate);
+  if (history.length === 0) {
+    dom.stats.innerHTML = `<p class="stats__latest"><a href="/" class="text-link">Go to latest puzzle</a></p>`;
+    dom.stats.classList.remove("hidden");
+    return;
+  }
+  const avg = (history.reduce((s, h) => s + h.tries, 0) / history.length).toFixed(1);
+  const last5 = history.slice(0, 5);
+  dom.stats.innerHTML = `
+    <p class="stats__heading">Your stats (to ${fDate})</p>
+    <div class="stats__grid">
+      <div class="stats__item"><span class="stats__val">${history.length}</span><span class="stats__lbl">Played</span></div>
+      <div class="stats__item"><span class="stats__val">${avg}</span><span class="stats__lbl">Avg tries</span></div>
+    </div>
+    <p class="stats__last-lbl">Last ${last5.length} game${last5.length !== 1 ? "s" : ""}</p>
+    <div class="stats__bubbles">${last5.map((h) => `<span class="stats__bubble">${h.tries}</span>`).join("")}</div>
+    <p class="stats__latest"><a href="/" class="text-link">Go to latest puzzle</a></p>
   `;
   dom.stats.classList.remove("hidden");
 }
@@ -437,10 +469,13 @@ function showNextPuzzle() {
   }
 }
 
-function showCompletedState(tries: number): void {
+function showCompletedState(tries: number, replayDate?: string): void {
   const t = tries === 1 ? "1 try" : `${tries} tries`;
   if (dom.feedback) {
-    dom.feedback.innerHTML = `${ICON_CHECK} You already solved today's puzzle in ${t}!`;
+    const message = replayDate
+      ? `You solved this puzzle in ${t}!`
+      : `You already solved today's puzzle in ${t}!`;
+    dom.feedback.innerHTML = `${ICON_CHECK} ${message}`;
     dom.feedback.className = "feedback feedback--correct";
     dom.feedback.classList.remove("hidden");
   }
@@ -452,8 +487,12 @@ function showCompletedState(tries: number): void {
   dom.hint?.classList.add("hidden");
   dom.digits?.classList.add("digit-correct");
   dom.submitWrap?.classList.remove("visible");
-  renderStats();
-  showNextPuzzle();
+  if (replayDate) {
+    renderStatsUpTo(replayDate);
+  } else {
+    renderStats();
+    showNextPuzzle();
+  }
 }
 
 function resetPuzzleUI() {
@@ -469,37 +508,32 @@ function resetPuzzleUI() {
   checkSubmit();
 }
 
-function startRandomPuzzle(puzzleData: { answer: number; clues: ClueData[] }): void {
-  const { answer, clues } = puzzleData;
-
+function startRandomPuzzle(clues: ClueData[], token: string): void {
   if (dom.plabel) dom.plabel.textContent = "Random puzzle";
 
   renderClues(clues);
 
-  gameState = { answer, guesses: [], solved: false, isRandom: true };
+  gameState = { answer: null, guesses: [], solved: false, isRandom: true, token };
   resetPuzzleUI();
   track("puzzle_start");
 
   dom.again?.classList.add("hidden");
-  // No score saving for random puzzles
   dom.save?.classList.add("hidden");
 }
 
-function startDailyPuzzle(puzzleData: { date: string; puzzleNumber: number; answer: number; clues: ClueData[] }): void {
-  const { date, puzzleNumber: num, answer, clues } = puzzleData;
-
+function startDailyPuzzle(date: string, num: number, clues: ClueData[]): void {
   if (dom.plabel) dom.plabel.textContent = `Puzzle #${num} · ${formatDate(date)}`;
 
   renderClues(clues);
 
   const entry = todayEntry();
   if (entry) {
-    gameState = { answer, guesses: [], solved: true, puzzleNum: num };
+    gameState = { answer: entry.answer ?? null, guesses: [], solved: true, puzzleNum: num, date };
     showCompletedState(entry.tries);
     return;
   }
 
-  gameState = { answer, guesses: [], solved: false, puzzleNum: num };
+  gameState = { answer: null, guesses: [], solved: false, puzzleNum: num, date };
   resetPuzzleUI();
   track("puzzle_start");
   const htpWasSeen = localStorage.getItem("cw-htp-seen");
@@ -513,60 +547,156 @@ function startDailyPuzzle(puzzleData: { date: string; puzzleNumber: number; answ
   if (dom.saveCheck) dom.saveCheck.checked = saveScore;
 }
 
-function handleGuess() {
-  if (gameState.solved) return;
+async function startReplayPuzzle(date: string, num: number, clues: ClueData[]): Promise<void> {
+  // Show archived puzzle label above the puzzle number
+  if (dom.plabel) {
+    const label = document.createElement("div");
+    label.className = "card__archive-label";
+    label.innerHTML = `<svg aria-hidden="true"><use href="/sprites.svg#icon-archive"/></svg> Archived puzzle`;
+    dom.plabel.parentElement?.insertBefore(label, dom.plabel);
+    dom.plabel.textContent = `Puzzle #${num} · ${formatDate(date)}`;
+  }
+
+  renderClues(clues);
+
+  // Check if already solved
+  const entry = loadHistory().find(h => h.date === date);
+  if (entry) {
+    let answer = entry.answer ?? null;
+    // Old history entries may not have the answer stored — fetch it
+    if (answer == null) {
+      try {
+        const res = await fetch(`/api/puzzle/${num}/solution`);
+        if (res.ok) {
+          const data = await res.json() as { answer: number };
+          answer = data.answer;
+        }
+      } catch { /* leave as null */ }
+    }
+    gameState = { answer, guesses: [], solved: true, puzzleNum: num, date };
+    showCompletedState(entry.tries, date);
+    dom.save?.classList.add("hidden");
+    return;
+  }
+
+  gameState = { answer: null, guesses: [], solved: false, puzzleNum: num, date };
+  resetPuzzleUI();
+  track("puzzle_start");
+
+  // Save score for replays
+  const prefs = loadPrefs();
+  saveScore = prefs.saveScore;
+  if (dom.saveCheck) dom.saveCheck.checked = saveScore;
+  dom.again?.classList.add("hidden");
+}
+
+async function handleGuess() {
+  if (gameState.solved || submitting) return;
   if (!possibles.every((s) => s.size === 1)) return;
 
   const guessStr = possibles.map((s) => [...s][0]).join("");
   const guess = Number(guessStr);
   const tries = gameState.guesses.length + 1;
 
-  if (guess === gameState.answer) {
-    gameState.solved = true;
-    track("puzzle_complete", tries);
-    launchConfetti();
-    renderFeedback("correct", gameState.answer ?? undefined);
-    closeKeypad();
-    dom.digits?.classList.add("digit-correct");
-    dom.submitWrap?.classList.remove("visible");
-    celebrateOcto();
-    if (gameState.isRandom) {
-      dom.again?.classList.remove("hidden");
-    } else {
-      if (saveScore) {
-        recordGame(todayLocal(), tries);
-        renderStats();
-      }
-      showNextPuzzle();
-    }
+  // Build request body
+  const body: { guess: number; date?: string; token?: string } = { guess };
+  if (gameState.token) {
+    body.token = gameState.token;
+  } else if (gameState.date) {
+    body.date = gameState.date;
   } else {
-    gameState.guesses.push(guess);
-    track("incorrect_guess");
-    renderFeedback("incorrect");
-    renderHistory(gameState.guesses);
-    sadOcto();
-    // Keep digits filled but hide submit — user can tap a box to change their guess
-    dom.submitWrap?.classList.remove("visible");
+    renderFeedback("error");
+    return;
+  }
+
+  submitting = true;
+  dom.submitBtn?.setAttribute("disabled", "true");
+
+  try {
+    const res = await fetch("/api/guess", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      renderFeedback("error");
+      return;
+    }
+
+    const result = await res.json() as { correct: boolean };
+
+    if (result.correct) {
+      gameState.solved = true;
+      gameState.answer = guess; // now we know the answer (it was our correct guess)
+      track("puzzle_complete", tries);
+      launchConfetti();
+      renderFeedback("correct", guess);
+      closeKeypad();
+      dom.digits?.classList.add("digit-correct");
+      dom.submitWrap?.classList.remove("visible");
+      celebrateOcto();
+      if (gameState.isRandom) {
+        dom.again?.classList.remove("hidden");
+      } else {
+        if (saveScore && gameState.date) {
+          recordGame(gameState.date, tries, guess);
+          renderStats();
+        }
+        showNextPuzzle();
+      }
+    } else {
+      gameState.guesses.push(guess);
+      track("incorrect_guess");
+      renderFeedback("incorrect");
+      renderHistory(gameState.guesses);
+      sadOcto();
+      dom.submitWrap?.classList.remove("visible");
+    }
+  } catch {
+    renderFeedback("error");
+  } finally {
+    submitting = false;
+    dom.submitBtn?.removeAttribute("disabled");
   }
 }
 
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
-function loadPuzzle() {
-  if (window.PUZZLE_DATA) {
-    if (window.PUZZLE_DATA.isRandom) {
-      startRandomPuzzle(window.PUZZLE_DATA);
-    } else {
-      const pd = window.PUZZLE_DATA;
-      if (pd.date && pd.puzzleNumber !== undefined) {
-        startDailyPuzzle({ date: pd.date, puzzleNumber: pd.puzzleNumber, answer: pd.answer, clues: pd.clues });
-      }
-    }
+async function loadPuzzle() {
+  const path = window.location.pathname;
+  const isRandom = path === '/random';
+  const replayMatch = path.match(/^\/puzzles\/(\d+)$/);
+
+  let endpoint: string;
+  if (isRandom) {
+    endpoint = '/api/puzzle/random';
+  } else if (replayMatch) {
+    endpoint = `/api/puzzle/${replayMatch[1]}`;
   } else {
+    endpoint = '/api/puzzle';
+  }
+
+  try {
+    const res = await fetch(endpoint);
+    if (!res.ok) throw new Error(`API ${res.status}`);
+
+    const data = await res.json() as any;
+
+    if (isRandom) {
+      startRandomPuzzle(data.clues, data.token);
+    } else if (replayMatch) {
+      startReplayPuzzle(data.date, data.puzzleNumber, data.clues);
+    } else {
+      startDailyPuzzle(data.date, data.puzzleNumber, data.clues);
+    }
+  } catch {
     if (dom.feedback) {
-      dom.feedback.textContent = 'Puzzle data not available. Please refresh the page.';
+      dom.feedback.textContent = 'Could not load the puzzle. Please refresh the page.';
       dom.feedback.classList.remove('hidden');
     }
+    // Hide skeleton on error
+    if (dom.clueList) dom.clueList.innerHTML = '';
   }
 }
 
@@ -588,7 +718,7 @@ for (let i = 0; i < 3; i++) {
 }
 
 // Submit button
-dom.submitBtn?.addEventListener("click", handleGuess);
+dom.submitBtn?.addEventListener("click", () => { handleGuess(); });
 
 // Save checkbox
 if (dom.saveCheck) {
@@ -672,9 +802,14 @@ document.querySelector('[data-swatches]')?.addEventListener('click', (e) => {
 
 // ─── Dev helpers (non-production only) ───────────────────────────────────────
 
-window._devFillAnswer = () => {
-  if (!gameState.answer) return;
-  const digits = [Math.floor(gameState.answer / 100), Math.floor((gameState.answer % 100) / 10), gameState.answer % 10];
-  digits.forEach((d, i) => { possibles[i] = new Set([d]); renderBox(i); });
-  checkSubmit();
+window._devFillAnswer = async () => {
+  try {
+    const params = gameState.token ? `?token=${encodeURIComponent(gameState.token)}` : '';
+    const res = await fetch(`/api/dev/answer${params}`);
+    if (!res.ok) return;
+    const { answer } = await res.json() as { answer: number };
+    const digits = [Math.floor(answer / 100), Math.floor((answer % 100) / 10), answer % 10];
+    digits.forEach((d, i) => { possibles[i] = new Set([d]); renderBox(i); });
+    checkSubmit();
+  } catch { /* dev only */ }
 };

--- a/src/colours.ts
+++ b/src/colours.ts
@@ -71,7 +71,7 @@ function renderDevLinks(): void {
   const addBtn = (label: string, fn: () => void): void => {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'dev-links__btn';
+    btn.className = 'text-link text-link--muted';
     btn.textContent = label;
     btn.addEventListener('click', fn);
     dev.appendChild(btn);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,8 +1,5 @@
-import type { PuzzleData } from './types.ts';
-
 declare global {
   interface Window {
-    PUZZLE_DATA?: PuzzleData;
     _swapIcons?: (colourName: string) => void;
     _currentColour?: string;
     _devFillAnswer?: () => void;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -26,8 +26,8 @@ export function loadHistory(): HistoryEntry[] {
   }
 }
 
-export function recordGame(dateStr: string, tries: number): void {
+export function recordGame(dateStr: string, tries: number, answer?: number): void {
   const history = loadHistory().filter((h) => h.date !== dateStr);
-  history.unshift({ date: dateStr, tries });
-  localStorage.setItem(STORAGE_HISTORY, JSON.stringify(history.slice(0, 60)));
+  history.unshift({ date: dateStr, tries, ...(answer != null && { answer }) });
+  localStorage.setItem(STORAGE_HISTORY, JSON.stringify(history));
 }

--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,11 @@
     background-color: var(--bg);
   }
 
+  :where(a) {
+    text-decoration: none;
+    color: inherit;
+  }
+
   :where(:focus-visible) {
     outline: 2px solid var(--acc);
     outline-offset: 2px;
@@ -319,6 +324,29 @@
     transition: color 0.4s;
   }
 
+  .card__archive-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-family: "Inconsolata", monospace;
+    font-size: 1rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    font-weight: 700;
+    padding: 0.5rem 1rem;
+    margin-block-end: 0.75rem;
+    border-radius: 0.25rem;
+    background: var(--acc);
+    color: var(--bg);
+    transition: background 0.4s, color 0.4s;
+
+    & svg {
+      width: 1rem;
+      height: 1rem;
+      flex-shrink: 0;
+    }
+  }
+
   /* ─── Card hint ─── */
   .card__hint {
     font-size: 1rem;
@@ -500,6 +528,48 @@
       line-height: 1;
     }
   }
+
+  /* ═══════════════════════════════════════
+     Clue skeleton (loading state)
+     ═══════════════════════════════════════ */
+
+  @keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+  }
+
+  .clue-skeleton {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    align-items: center;
+  }
+
+  .clue-skeleton__tag {
+    width: 4rem;
+    height: 2rem;
+    border-radius: 0.375rem;
+    background: linear-gradient(90deg, var(--border) 25%, var(--surface) 50%, var(--border) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite ease-in-out;
+  }
+
+  .clue-skeleton__lines {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .clue-skeleton__line {
+    height: 0.85rem;
+    border-radius: 0.25rem;
+    background: linear-gradient(90deg, var(--border) 25%, var(--surface) 50%, var(--border) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite ease-in-out;
+  }
+
+  .clue-skeleton__line--long { width: 80%; }
+  .clue-skeleton__line--short { width: 40%; }
 
   /* ═══════════════════════════════════════
      Digit entry boxes
@@ -876,6 +946,11 @@
     gap: 0.375rem;
   }
 
+  .stats__latest {
+    margin-block-start: 1rem;
+    font-size: 1rem;
+  }
+
   .stats__bubble {
     font-family: "Inconsolata", monospace;
     font-size: 1rem;
@@ -919,14 +994,6 @@
     margin-block-start: 0.875rem;
   }
 
-  .play-again__link {
-    color: var(--acc);
-    text-decoration: underline;
-    text-underline-offset: 0.1875rem;
-    font-size: 1rem;
-    transition: color 0.4s;
-  }
-
   /* ═══════════════════════════════════════
      Footer links row
      ═══════════════════════════════════════ */
@@ -938,31 +1005,6 @@
     inline-size: 100%;
   }
 
-  .ui-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3125rem;
-    background: none;
-    border: none;
-    padding: 0;
-    color: var(--acc);
-    font-size: 1rem;
-    line-height: 1.4;
-    cursor: pointer;
-    transition: color 0.4s;
-
-    & svg {
-      width: 0.875rem;
-      height: 0.875rem;
-      flex-shrink: 0;
-      stroke: var(--acc);
-      transition: stroke 0.4s;
-    }
-
-    & > span:last-child {
-      border-block-end: 1px solid var(--acc);
-    }
-  }
 
   .theme-icon {
     display: inline-flex;
@@ -996,19 +1038,12 @@
     color: var(--muted);
     transition: color 0.4s;
 
-    & a {
-      text-decoration: underline;
-      text-underline-offset: 0.1875rem;
-      color: var(--acc);
-      transition: color 0.4s;
-    }
   }
 
   .foot-icon-link {
     display: inline-flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.25rem;
-    vertical-align: middle;
 
     & svg {
       color: var(--text);
@@ -1024,11 +1059,6 @@
     display: block;
   }
 
-  .footer__copyright {
-    margin: 0;
-    color: var(--muted);
-    transition: color 0.4s;
-  }
 
   /* ─── Footer heart ─── */
   @keyframes heart-bounce {
@@ -1100,15 +1130,6 @@
     inline-size: 100%;
   }
 
-  .dev-links__btn {
-    background: none;
-    border: none;
-    border-block-end: 1px solid var(--muted);
-    color: var(--muted);
-    font-size: 1rem;
-    padding: 0;
-    cursor: pointer;
-  }
 
   /* ═══════════════════════════════════════
      How-to-play modal
@@ -1426,27 +1447,6 @@
     margin-block-end: 0.75rem;
   }
 
-  .fb-header-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3125rem;
-    background: none;
-    border: none;
-    border-block-end: 1px solid var(--muted);
-    color: var(--muted);
-    font-family: "DM Sans", system-ui, sans-serif;
-    font-size: 1rem;
-    line-height: 1.4;
-    padding: 0;
-    cursor: pointer;
-    transition: color 0.4s;
-
-    & svg {
-      flex-shrink: 0;
-      stroke: var(--muted);
-      transition: stroke 0.4s;
-    }
-  }
 
   /* ═══════════════════════════════════════
      Feedback modal
@@ -1731,6 +1731,52 @@
     border: 0;
   }
 
+  /* ─── Unified text link ───
+     Works on <a> and <button>. Underline via border on the element
+     itself — no child spans needed. Colour set by the parent or
+     overridden with a modifier (--link-color).
+     Icon links: use with inline-flex + gap for icon + text. */
+  .text-link {
+    display: inline-block;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    line-height: 1;
+    color: var(--link-color, var(--acc));
+    cursor: pointer;
+    border-block-end: 1px solid currentColor;
+    padding-block-end: 0.25rem;
+    transition: color 0.4s;
+  }
+
+  /* Icon variant: border goes on text span only; icon aligns with text top */
+  .text-link--icon {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 0.3125rem;
+    border-block-end: none;
+    padding-block-end: 0;
+
+    & svg {
+      width: 1rem;
+      height: 1rem;
+      flex-shrink: 0;
+      stroke: currentColor;
+      transition: stroke 0.4s;
+    }
+
+    & > span:last-child {
+      line-height: 1;
+      border-block-end: 1px solid currentColor;
+      padding-block-end: 0.25rem;
+    }
+  }
+
+  .text-link--muted {
+    --link-color: var(--muted);
+  }
+
   .skip-link {
     position: absolute;
     inset-inline-start: -999rem;
@@ -1741,7 +1787,6 @@
     color: #fff;
     font-weight: 600;
     border-radius: 0.25rem;
-    text-decoration: none;
 
     &:focus-visible {
       inset-inline-start: 1rem;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,25 +5,20 @@ export interface ClueData {
   value: number | boolean;
 }
 
-export interface PuzzleData {
-  date?: string;
-  puzzleNumber?: number;
-  answer: number;
-  clues: ClueData[];
-  isRandom?: boolean;
-}
-
 export interface GameState {
   answer: number | null;
   guesses: number[];
   solved: boolean;
   puzzleNum?: number;
   isRandom?: boolean;
+  date?: string;
+  token?: string;
 }
 
 export interface HistoryEntry {
   date: string;
   tries: number;
+  answer?: number;
 }
 
 export interface Prefs {

--- a/src/worker/crypto.ts
+++ b/src/worker/crypto.ts
@@ -1,0 +1,56 @@
+// Crypto helpers for random puzzle tokens.
+// Uses Web Crypto API (available in Cloudflare Workers).
+// Tokens are AES-GCM encrypted seeds — opaque to the client.
+
+async function getKey(secret: string): Promise<CryptoKey> {
+  const enc = new TextEncoder();
+  const raw = await crypto.subtle.digest('SHA-256', enc.encode(secret));
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', false, ['encrypt', 'decrypt']);
+}
+
+function toHex(buf: ArrayBuffer): string {
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/** Encrypt a random seed into an opaque token string. */
+export async function signToken(seed: number, secret: string): Promise<string> {
+  const key = await getKey(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const data = new TextEncoder().encode(String(seed));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+  return toHex(iv.buffer as ArrayBuffer) + '.' + toHex(ciphertext);
+}
+
+/** Decrypt a token back to the seed. Returns the seed if valid, null otherwise. */
+export async function verifyToken(token: string, secret: string): Promise<number | null> {
+  const dotIdx = token.indexOf('.');
+  if (dotIdx < 1) return null;
+
+  const ivHex = token.slice(0, dotIdx);
+  const ctHex = token.slice(dotIdx + 1);
+
+  try {
+    const key = await getKey(secret);
+    const iv = fromHex(ivHex);
+    const ct = fromHex(ctHex);
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+      key,
+      ct.buffer as ArrayBuffer,
+    );
+    const seedStr = new TextDecoder().decode(plaintext);
+    const seed = Number(seedStr);
+    if (!Number.isFinite(seed) || seed !== Math.floor(seed)) return null;
+    return seed;
+  } catch {
+    return null;
+  }
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,13 +1,24 @@
-// Worker entry point — intercepts GET / and /random to inject puzzle data into HTML.
+// Worker entry point — serves API routes for puzzle data and guess validation.
+// The answer is never sent to the client.
 
-import { runFilterLoop, makeRng, dateSeedInt, todayLocal, puzzleNumber } from './puzzle.ts';
+import { runFilterLoop, makeRng, dateSeedInt, todayLocal, puzzleNumber, puzzleDate } from './puzzle.ts';
+import { signToken, verifyToken } from './crypto.ts';
 import { getStats, renderDashboard } from './stats.ts';
+import { renderPuzzlesPage } from './puzzles.ts';
 
 interface Env {
   ASSETS: { fetch: (req: Request) => Promise<Response> };
   ANALYTICS: AnalyticsEngineDataset;
+  PUZZLES: KVNamespace;
+  HMAC_SECRET: string;
   CF_ACCOUNT_ID: string;
   CF_API_TOKEN: string;
+}
+
+interface StoredPuzzle {
+  answer: number;
+  clues: { propKey: string; label: string; operator: string; value: number | boolean }[];
+  puzzleNumber: number;
 }
 
 const VALID_EVENTS = new Set([
@@ -16,53 +27,148 @@ const VALID_EVENTS = new Set([
   'theme_toggle', 'colour_change', 'tooltip_opened',
 ]);
 
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── Puzzle generation + KV caching ──────────────────────────────────────────
+
+async function getDailyPuzzle(env: Env, date: string): Promise<StoredPuzzle> {
+  // Try KV first
+  const cached = await env.PUZZLES.get<StoredPuzzle>(date, 'json');
+  if (cached) return cached;
+
+  // Generate and store
+  const rng = makeRng(dateSeedInt(date));
+  const { answer, clues } = runFilterLoop(rng);
+  const puzzle: StoredPuzzle = { answer, clues, puzzleNumber: puzzleNumber(date) };
+  await env.PUZZLES.put(date, JSON.stringify(puzzle));
+  return puzzle;
+}
+
+// ─── Route handlers ──────────────────────────────────────────────────────────
+
+async function handleGetPuzzle(env: Env): Promise<Response> {
+  const today = todayLocal();
+  const puzzle = await getDailyPuzzle(env, today);
+  return json({
+    date: today,
+    puzzleNumber: puzzle.puzzleNumber,
+    clues: puzzle.clues,
+  });
+}
+
+async function handleGetRandomPuzzle(env: Env): Promise<Response> {
+  const seed = Math.floor(Math.random() * 0xFFFFFFFF);
+  const rng = makeRng(seed);
+  const { clues } = runFilterLoop(rng);
+  const token = await signToken(seed, env.HMAC_SECRET);
+  return json({ isRandom: true, clues, token });
+}
+
+async function handleGuess(request: Request, env: Env): Promise<Response> {
+  let body: { date?: string; token?: string; guess?: number };
+  try {
+    body = await request.json() as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { guess } = body;
+  if (typeof guess !== 'number' || !Number.isInteger(guess) || guess < 100 || guess > 999) {
+    return json({ error: 'Guess must be an integer between 100 and 999' }, 400);
+  }
+
+  // Random puzzle — verify token and re-derive answer
+  if (body.token) {
+    const seed = await verifyToken(body.token, env.HMAC_SECRET);
+    if (seed === null) return json({ error: 'Invalid token' }, 400);
+
+    const rng = makeRng(seed);
+    const { answer } = runFilterLoop(rng);
+    return json({ correct: guess === answer });
+  }
+
+  // Daily puzzle — look up from KV
+  if (body.date) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
+      return json({ error: 'Invalid date format' }, 400);
+    }
+    if (body.date > todayLocal()) {
+      return json({ error: 'Cannot guess future puzzles' }, 400);
+    }
+    const puzzle = await getDailyPuzzle(env, body.date);
+    return json({ correct: guess === puzzle.answer });
+  }
+
+  return json({ error: 'Provide either date or token' }, 400);
+}
+
+// ─── Main fetch handler ──────────────────────────────────────────────────────
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
-      const today = todayLocal();
-      const rng = makeRng(dateSeedInt(today));
-      const { answer, clues } = runFilterLoop(rng);
-      const puzzleData = { date: today, puzzleNumber: puzzleNumber(today), answer, clues };
+    // ── API routes ──
 
-      // Fetch static index.html from Pages assets, inject puzzle data before </head>
-      const assetRes = await env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
-      const html = await assetRes.text();
-      const injected = html.replace(
-        '</head>',
-        `<script>window.PUZZLE_DATA=${JSON.stringify(puzzleData)}</script></head>`
-      );
-
-      return new Response(injected, {
-        headers: { 'Content-Type': 'text/html; charset=utf-8' },
-      });
+    if (request.method === 'GET' && url.pathname === '/api/puzzle') {
+      return handleGetPuzzle(env);
     }
 
-    if (request.method === 'GET' && url.pathname === '/random') {
-      try {
-        const seed = Math.floor(Math.random() * 0xFFFFFFFF);
+    if (request.method === 'GET' && url.pathname === '/api/puzzle/random') {
+      return handleGetRandomPuzzle(env);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/api/guess') {
+      return handleGuess(request, env);
+    }
+
+    // GET /api/puzzle/:num — return clues for a specific puzzle number (no answer)
+    const puzzleByNum = url.pathname.match(/^\/api\/puzzle\/(\d+)$/);
+    if (request.method === 'GET' && puzzleByNum) {
+      const num = parseInt(puzzleByNum[1], 10);
+      if (num < 1) return json({ error: 'Invalid puzzle number' }, 400);
+      const date = puzzleDate(num);
+      if (date > todayLocal()) return json({ error: 'Puzzle not available yet' }, 400);
+      const puzzle = await getDailyPuzzle(env, date);
+      return json({ date, puzzleNumber: num, clues: puzzle.clues });
+    }
+
+    // GET /api/puzzle/:num/solution — return answer for a PAST puzzle (not today)
+    // Used to reveal the answer in the already-solved state when the client's
+    // history entry predates answer-saving. Today's puzzle is protected.
+    const solutionByNum = url.pathname.match(/^\/api\/puzzle\/(\d+)\/solution$/);
+    if (request.method === 'GET' && solutionByNum) {
+      const num = parseInt(solutionByNum[1], 10);
+      if (num < 1) return json({ error: 'Invalid puzzle number' }, 400);
+      const date = puzzleDate(num);
+      if (date >= todayLocal()) return json({ error: 'Solution not available' }, 403);
+      const puzzle = await getDailyPuzzle(env, date);
+      return json({ answer: puzzle.answer });
+    }
+
+    // Dev-only: return the answer for the current puzzle (blocked on production domain)
+    if (request.method === 'GET' && url.pathname === '/api/dev/answer') {
+      if (url.hostname === 'clumeral.com') return new Response('Not found', { status: 404 });
+      const token = url.searchParams.get('token');
+      if (token) {
+        const seed = await verifyToken(token, env.HMAC_SECRET);
+        if (seed === null) return json({ error: 'Invalid token' }, 400);
         const rng = makeRng(seed);
-        const { answer, clues } = runFilterLoop(rng);
-        const puzzleData = { isRandom: true, answer, clues };
-
-        const assetRes = await env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
-        const html = await assetRes.text();
-        const injected = html.replace(
-          '</head>',
-          `<script>window.PUZZLE_DATA=${JSON.stringify(puzzleData)}</script></head>`
-        );
-
-        return new Response(injected, {
-          headers: { 'Content-Type': 'text/html; charset=utf-8' },
-        });
-      } catch (err: unknown) {
-        const e = err instanceof Error ? err : new Error(String(err));
-        return new Response(`/random error: ${e.message}\n${e.stack}`, { status: 500 });
+        const { answer } = runFilterLoop(rng);
+        return json({ answer });
       }
+      const today = todayLocal();
+      const puzzle = await getDailyPuzzle(env, today);
+      return json({ answer: puzzle.answer });
     }
 
-    // POST /api/event — record an analytics event
+    // ── Analytics ──
+
     if (request.method === 'POST' && url.pathname === '/api/event') {
       try {
         const body = await request.json() as { event?: string; uid?: string; value?: number; newUser?: boolean; source?: string };
@@ -81,7 +187,8 @@ export default {
       }
     }
 
-    // GET /api/stats — JSON stats data
+    // ── Stats ──
+
     if (request.method === 'GET' && url.pathname === '/api/stats') {
       try {
         if (!env.CF_ACCOUNT_ID || !env.CF_API_TOKEN) {
@@ -98,7 +205,6 @@ export default {
       }
     }
 
-    // GET /stats — rendered dashboard
     if (request.method === 'GET' && url.pathname === '/stats') {
       try {
         if (!env.CF_ACCOUNT_ID || !env.CF_API_TOKEN) {
@@ -122,6 +228,52 @@ export default {
       }
     }
 
+    // ── Puzzles ──
+
+    // GET /puzzles — Worker-rendered puzzle history page
+    if (request.method === 'GET' && url.pathname === '/puzzles') {
+      const today = todayLocal();
+      const todayNum = puzzleNumber(today);
+      const keys = await env.PUZZLES.list();
+      const puzzles = await Promise.all(
+        keys.keys
+          .filter(k => /^\d{4}-\d{2}-\d{2}$/.test(k.name) && k.name <= today)
+          .map(async k => {
+            const p = await env.PUZZLES.get<StoredPuzzle>(k.name, 'json');
+            return p ? { num: puzzleNumber(k.name), date: k.name, clues: p.clues.length } : null;
+          })
+      );
+      // Include today if not yet in KV
+      const dates = new Set(keys.keys.map(k => k.name));
+      if (!dates.has(today)) {
+        const p = await getDailyPuzzle(env, today);
+        puzzles.push({ num: todayNum, date: today, clues: p.clues.length });
+      }
+      const valid = puzzles.filter((p): p is NonNullable<typeof p> => p !== null);
+      const html = renderPuzzlesPage(valid);
+      return new Response(html, {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    // GET /puzzles/:num — serve game HTML for replay
+    if (request.method === 'GET' && /^\/puzzles\/\d+$/.test(url.pathname)) {
+      return env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
+    }
+
+    // ── Static pages ──
+
+    // GET / and /random — serve static HTML (client fetches puzzle via API)
+    if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html' || url.pathname === '/random')) {
+      return env.ASSETS.fetch(new Request(new URL('/index.html', request.url)));
+    }
+
     return env.ASSETS.fetch(request);
+  },
+
+  // ── Cron: pre-generate today's puzzle at midnight UTC ──
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    const today = todayLocal();
+    await getDailyPuzzle(env, today);
   },
 };

--- a/src/worker/puzzle.ts
+++ b/src/worker/puzzle.ts
@@ -193,6 +193,12 @@ export function dateSeedInt(dateStr: string): number {
 const EPOCH_DATE = '2026-03-08';
 
 export function puzzleNumber(dateStr: string): number {
-  const ms = new Date(dateStr + 'T00:00:00').getTime() - new Date(EPOCH_DATE + 'T00:00:00').getTime();
+  const ms = new Date(dateStr + 'T00:00:00Z').getTime() - new Date(EPOCH_DATE + 'T00:00:00Z').getTime();
   return Math.max(1, Math.floor(ms / 86400000) + 1);
+}
+
+export function puzzleDate(num: number): string {
+  const epoch = new Date(EPOCH_DATE + 'T00:00:00Z');
+  const d = new Date(epoch.getTime() + (num - 1) * 86400000);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 }

--- a/src/worker/puzzles.ts
+++ b/src/worker/puzzles.ts
@@ -1,0 +1,212 @@
+// Worker-rendered puzzle history page at /puzzles
+
+interface PuzzleSummary {
+  num: number;
+  date: string;
+  clues: number;
+}
+
+function fmtDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  const day = d.getDate();
+  const mon = d.toLocaleDateString('en-GB', { month: 'short' });
+  const yr = d.getFullYear();
+  const now = new Date().getFullYear();
+  return yr !== now ? `${day} ${mon}, ${String(yr).slice(2)}` : `${day} ${mon}`;
+}
+
+export function renderPuzzlesPage(puzzles: PuzzleSummary[]): string {
+  const rows = puzzles
+    .sort((a, b) => b.num - a.num)
+    .map(p => `["${p.date}",${p.num},${p.clues}]`)
+    .join(',');
+
+  const tableRows = puzzles
+    .sort((a, b) => b.num - a.num)
+    .map(p =>
+      `<tr class="row" data-num="${p.num}" data-date="${p.date}" data-clues="${p.clues}">
+        <td><a href="/puzzles/${p.num}">${p.num}</a></td>
+        <td>${fmtDate(p.date)}</td>
+        <td class="num-col">${p.clues}</td>
+        <td class="num-col" data-tries></td>
+      </tr>`
+    )
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Clumeral — Puzzles</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Inconsolata:wght@500;700&display=swap" rel="stylesheet">
+<script>
+  (function () {
+    var t = localStorage.getItem("dlng_theme");
+    if (!t) t = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    document.documentElement.classList.add(t);
+  })();
+</script>
+<style>
+  :root { color-scheme: light dark; --acc: light-dark(#0a850a, #1ead52); }
+  :root.dark { color-scheme: dark; }
+  :root.light { color-scheme: light; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: "DM Sans", system-ui, sans-serif;
+    background: light-dark(#f5edd8, #262624);
+    color: light-dark(#262624, #f6f0e8);
+    padding: 1.5rem 1rem;
+    max-width: 32rem;
+    margin: 0 auto;
+  }
+  a { color: var(--acc); text-decoration: none; border-block-end: 1px solid currentColor; padding-block-end: 0.125rem; }
+  .back { font-size: 1rem; margin-block-end: 1rem; display: inline-block; }
+  h1 { font-size: 1.5rem; margin-block-end: 0.25rem; }
+  .subtitle {
+    font-size: 1rem;
+    color: light-dark(rgba(38,38,36,0.7), rgba(246,240,232,0.6));
+    margin-block-end: 1.5rem;
+  }
+  table { width: 100%; border-collapse: collapse; }
+  th, td {
+    padding: 0.5rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid light-dark(rgba(38,38,36,0.1), rgba(255,253,247,0.08));
+  }
+  th {
+    font-size: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: light-dark(rgba(38,38,36,0.5), rgba(246,240,232,0.4));
+    border-bottom: 2px solid light-dark(rgba(38,38,36,0.15), rgba(255,253,247,0.12));
+    white-space: nowrap;
+    user-select: none;
+  }
+  th.sortable { cursor: pointer; }
+  th.sortable .sort-label {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    text-decoration-thickness: 1.5px;
+    text-decoration-color: light-dark(rgba(38,38,36,0.3), rgba(246,240,232,0.3));
+  }
+  th.sortable:hover .sort-label {
+    text-decoration-color: light-dark(rgba(38,38,36,0.6), rgba(246,240,232,0.6));
+  }
+  .sort-icon {
+    display: none;
+    width: 12px;
+    height: 12px;
+    vertical-align: -1px;
+    margin-inline-start: 0.2rem;
+    transition: transform 0.15s;
+  }
+  th.sorted .sort-icon { display: inline-block; }
+  th.sorted.asc .sort-icon { transform: rotate(180deg); }
+  td:first-child {
+    font-family: "Inconsolata", monospace;
+    font-weight: 700;
+    width: 3rem;
+  }
+  td:first-child a {
+    color: var(--acc);
+  }
+  .num-col { font-family: "Inconsolata", monospace; font-weight: 600; text-align: right; }
+  th.num-header { text-align: right; }
+  .play-link {
+    font-family: "DM Sans", system-ui, sans-serif;
+    font-weight: 600;
+    font-size: 1rem;
+  }
+  tr.row { cursor: pointer; transition: background 0.1s; }
+  tr.row:hover { background: light-dark(rgba(10,133,10,0.04), rgba(30,173,82,0.06)); }
+  tr.row:active { background: light-dark(rgba(10,133,10,0.08), rgba(30,173,82,0.1)); }
+</style>
+</head>
+<body>
+  <a href="/" class="back">&larr; Back to today's puzzle</a>
+  <h1>Every Clumeral ever.</h1>
+  <p class="subtitle">Tap to replay a puzzle. Tap a column to sort by it.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th class="sortable sorted desc" data-sort="date" data-type="num"><span class="sort-label">Date</span> <svg class="sort-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></th>
+        <th class="sortable num-header" data-sort="clues" data-type="num"><span class="sort-label">Clues</span> <svg class="sort-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></th>
+        <th class="num-header">Tries</th>
+      </tr>
+    </thead>
+    <tbody id="tbody">
+      ${tableRows}
+    </tbody>
+  </table>
+
+<script>
+// Populate tries column from localStorage
+(function() {
+  var history = [];
+  try { history = JSON.parse(localStorage.getItem("dlng_history") || "[]"); } catch(e) {}
+  var byDate = {};
+  for (var i = 0; i < history.length; i++) byDate[history[i].date] = history[i].tries;
+
+  var rows = document.querySelectorAll("tr.row");
+  for (var r = 0; r < rows.length; r++) {
+    var date = rows[r].getAttribute("data-date");
+    var num = rows[r].getAttribute("data-num");
+    var cell = rows[r].querySelector("[data-tries]");
+    if (byDate[date] != null) {
+      cell.textContent = byDate[date];
+    } else {
+      cell.innerHTML = '<a href="/puzzles/' + num + '" class="play-link">Play</a>';
+    }
+  }
+})();
+
+// Sorting
+var sortKey = "date";
+var sortAsc = false;
+var tbody = document.getElementById("tbody");
+
+function sortRows() {
+  var rows = Array.from(tbody.querySelectorAll("tr.row"));
+  rows.sort(function(a, b) {
+    var va, vb;
+    if (sortKey === "date") {
+      va = parseInt(a.getAttribute("data-num"));
+      vb = parseInt(b.getAttribute("data-num"));
+    } else {
+      va = parseInt(a.getAttribute("data-" + sortKey));
+      vb = parseInt(b.getAttribute("data-" + sortKey));
+    }
+    return sortAsc ? va - vb : vb - va;
+  });
+  for (var i = 0; i < rows.length; i++) tbody.appendChild(rows[i]);
+}
+
+document.querySelectorAll("th.sortable").forEach(function(th) {
+  th.addEventListener("click", function() {
+    var key = th.getAttribute("data-sort");
+    if (sortKey === key) { sortAsc = !sortAsc; }
+    else { sortKey = key; sortAsc = false; }
+    document.querySelectorAll("th.sortable").forEach(function(h) {
+      h.classList.remove("sorted", "asc", "desc");
+    });
+    th.classList.add("sorted", sortAsc ? "asc" : "desc");
+    sortRows();
+  });
+});
+
+// Row click navigation
+document.querySelectorAll("tr.row").forEach(function(row) {
+  row.addEventListener("click", function(e) {
+    if (e.target.tagName === "A") return;
+    location.href = "/puzzles/" + row.getAttribute("data-num");
+  });
+});
+</script>
+</body>
+</html>`;
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,12 +4,21 @@
   "main": "./src/worker/index.ts",
   "assets": {
     "binding": "ASSETS",
-    "run_worker_first": ["/", "/index.html", "/random", "/api/*", "/stats"]
+    "run_worker_first": ["/", "/index.html", "/random", "/puzzles", "/puzzles/*", "/api/*", "/stats"]
   },
   "analytics_engine_datasets": [
     {
       "binding": "ANALYTICS",
       "dataset": "clumeral"
     }
-  ]
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "PUZZLES",
+      "id": "d07cfc9a455943e3839967475925a468"
+    }
+  ],
+  "triggers": {
+    "crons": ["0 0 * * *"]
+  }
 }


### PR DESCRIPTION
## Summary
**This PR replaces the closed #168** — same content, but as a single commit on top of main to bypass staging/main divergence conflicts (see [explanation below](#divergence-fix)).

### #95 — Server-side puzzle logic with answer validation API
- API endpoints: \`GET /api/puzzle\`, \`GET /api/puzzle/random\`, \`POST /api/guess\`
- Daily puzzles cached in Cloudflare KV with cron pre-generation at midnight UTC
- Random puzzle tokens encrypted with AES-GCM (opaque to client)
- Client shows skeleton shimmer while loading clues from API
- Service worker excludes \`/api/*\` from cache
- Answer never sent to the client

### #160 — Puzzle archive with replay
- \`/puzzles\` page lists all historical puzzles (sortable by date or clue count)
- Replay any past puzzle at \`/puzzles/:num\` — server-side validation
- Already-solved puzzles show stats up to that date with "Go to latest" link
- Footer renamed "How to play" → "Guide" for one-word consistency
- All link styling unified into \`.text-link\` class (removed ~50 lines of CSS)
- Archive icon added to sprites.svg
- Archive label uses the player's chosen accent colour
- Fixed DST-induced off-by-one bug in puzzle number calculation
- Removed 60-entry history cap from localStorage

### Post-merge fixes
- Footer icon alignment for GitHub/Jamie links
- Absolute paths for static assets on \`/puzzles/:num\` routes
- \`/api/puzzle/:num/solution\` endpoint for past puzzles
- Reworked already-solved feedback layout
- Footer wording: "Hosted on GitHub" → "It's on GitHub"

### Follow-up issues created
- #161, #162, #163, #165, #169

<a name="divergence-fix"></a>
## Why this PR replaces #168
PR #157 was previously merged as \`staging → main\` with a merge commit. That created commits on main whose content overlapped with what staging still had. Later work on staging (the \`.text-link\` CSS refactor) removed some of that overlapping content. Git's three-way merge then saw "main kept it, staging removed it" and flagged a conflict — even though it was a clean intentional removal.

Because staging is protected (no merge commits, no force-push), the conflict couldn't be resolved through the normal PR flow. This branch sits directly on main with staging's content applied as a single commit.

## After this merges
Staging will need to be re-synced with main. CLAUDE.md will also be updated to document the post-merge sync step to prevent this recurring.

## Test plan
- [ ] Daily puzzle loads and plays correctly
- [ ] Random puzzle works
- [ ] Archive page lists all puzzles, sorting works
- [ ] Replay unplayed puzzle saves score
- [ ] Replay solved puzzle shows completion state with filled digits
- [ ] \`window.PUZZLE_DATA\` no longer exists in browser
- [ ] Light/dark themes both render correctly
- [ ] Mobile footer fits on one line
- [ ] Jamie photo + favicon load on \`/puzzles/:num\` routes
- [ ] Archive label matches user's chosen accent colour

🤖 Generated with [Claude Code](https://claude.com/claude-code)