### PR TITLE
Fix octopus layout jump on celebrate/sad

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
       <main class="game__inner">
         <!-- ── Header row: octo + title ── -->
         <header class="header">
+          <div class="octo-slot" data-octo-slot>
           <div class="octo" data-octo-wrap title="click to replay" aria-hidden="true">
             <svg data-octo width="53" height="52" viewBox="0 0 53 52" fill="none" xmlns="http://www.w3.org/2000/svg">
               <mask id="octo-mask" fill="white">
@@ -187,7 +188,7 @@
               </g>
             </svg>
           </div>
-          <div class="octo__placeholder" data-octo-placeholder></div>
+          </div>
           <!-- ── Title ── -->
           <h1 class="title">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 218 43" fill="currentColor" aria-label="Clumeral">

--- a/src/octo.ts
+++ b/src/octo.ts
@@ -6,6 +6,7 @@
 
 const octoEl     = document.querySelector('[data-octo]') as HTMLElement | null;
 const octoWrapEl = document.querySelector('[data-octo-wrap]') as HTMLElement | null;
+const octoSlotEl = document.querySelector('[data-octo-slot]') as HTMLElement | null;
 const tlts       = [...document.querySelectorAll('.tlt')] as HTMLElement[];
 
 // ── Eye / mouth elements ──
@@ -252,9 +253,6 @@ export function celebrateOcto(): void {
   octoWrapEl.style.top = '50%';
   octoWrapEl.style.margin = '0';
 
-  const ph = document.querySelector('[data-octo-placeholder]') as HTMLElement | null;
-  if (ph) ph.classList.remove('hidden');
-
   octoEl.classList.add('celebrate');
   octoWrapEl.classList.add('celebrating');
   document.body.style.overflow = 'hidden';
@@ -266,11 +264,18 @@ export function celebrateOcto(): void {
     octoWrapEl.classList.remove('celebrating');
     octoEl.classList.remove('celebrate');
 
+    // Re-measure the slot NOW so we animate back to where home actually
+    // is at this moment — not where it was 5s ago. Handles resize/scroll
+    // mid-celebration and avoids a settle-snap on cleanup.
+    const home = octoSlotEl?.getBoundingClientRect();
+    const returnLeft = home ? home.left : origLeft;
+    const returnTop = home ? home.top : origTop;
+
     requestAnimationFrame(() => {
       if (!octoWrapEl) return;
       octoWrapEl.style.transition = 'left 0.6s ease-in-out, top 0.6s ease-in-out, transform 0.6s ease-in-out';
-      octoWrapEl.style.left = origLeft + 'px';
-      octoWrapEl.style.top = origTop + 'px';
+      octoWrapEl.style.left = returnLeft + 'px';
+      octoWrapEl.style.top = returnTop + 'px';
       octoWrapEl.style.transform = '';
 
       setTimeout(() => {
@@ -281,9 +286,6 @@ export function celebrateOcto(): void {
         octoWrapEl.style.margin = '';
         octoWrapEl.style.transition = '';
         octoWrapEl.style.opacity = '1';
-
-        const ph = document.querySelector('[data-octo-placeholder]') as HTMLElement | null;
-        if (ph) ph.classList.add('hidden');
 
         const digitsEl = document.querySelector('[data-digits]') as HTMLElement | null;
         if (digitsEl) digitsEl.classList.add('digit-correct');
@@ -365,9 +367,6 @@ export function sadOcto(): void {
   octoWrapEl.style.transition = 'none';
   octoWrapEl.style.zIndex = '9999';
 
-  const ph = document.querySelector('[data-octo-placeholder]') as HTMLElement | null;
-  if (ph) ph.classList.remove('hidden');
-
   // Animate fall + bounce, then settle on side
   sadBounce(octoWrapEl, fallDist, () => {
     if (!octoWrapEl) return;
@@ -410,7 +409,6 @@ export function sadOcto(): void {
           octoWrapEl.style.transition = '';
           octoWrapEl.style.zIndex = '';
 
-          if (ph) ph.classList.add('hidden');
           octoAnimating = false;
         }, 450);
       }, 900);

--- a/src/octo.ts
+++ b/src/octo.ts
@@ -248,16 +248,37 @@ export function celebrateOcto(): void {
   const origLeft = rect.left;
   const origTop = rect.top;
 
+  // Pin him in place at his current header-slot coords first, so the
+  // lead-in transition below starts from exactly where the user sees him
+  // — no teleport to the keyframe's start position.
   octoWrapEl.style.position = 'fixed';
-  octoWrapEl.style.left = '50%';
-  octoWrapEl.style.top = '50%';
+  octoWrapEl.style.left = origLeft + 'px';
+  octoWrapEl.style.top = origTop + 'px';
   octoWrapEl.style.margin = '0';
-
-  octoEl.classList.add('celebrate');
-  octoWrapEl.classList.add('celebrating');
+  octoWrapEl.style.transform = '';
   document.body.style.overflow = 'hidden';
 
-  // After fly animation ends, transition back to header
+  // Lead-in: slide from the header slot to the `octo-fly` keyframe's 0%
+  // position (centre + translateY(-55vh)) over 350ms. The keyframe 0% is
+  // identical to where we end, so handing off to the CSS animation after
+  // the transition is seamless — no jump.
+  const LEAD_IN_MS = 350;
+  requestAnimationFrame(() => {
+    if (!octoWrapEl || !octoEl) return;
+    octoWrapEl.style.transition = `left ${LEAD_IN_MS}ms ease-in, top ${LEAD_IN_MS}ms ease-in, transform ${LEAD_IN_MS}ms ease-in`;
+    octoWrapEl.style.left = '50%';
+    octoWrapEl.style.top = '50%';
+    octoWrapEl.style.transform = 'translate(-50%, -50%) translateY(-55vh)';
+
+    setTimeout(() => {
+      if (!octoWrapEl || !octoEl) return;
+      octoWrapEl.style.transition = '';
+      octoEl.classList.add('celebrate');
+      octoWrapEl.classList.add('celebrating');
+    }, LEAD_IN_MS);
+  });
+
+  // After lead-in + fly animation ends, transition back to header
   setTimeout(() => {
     if (!octoWrapEl || !octoEl) return;
     octoWrapEl.style.transform = 'translate(-50%, -50%)';
@@ -295,7 +316,7 @@ export function celebrateOcto(): void {
         octoAnimating = false;
       }, 650);
     });
-  }, 5100);
+  }, 5100 + 350);
 }
 
 function sadBounce(el: HTMLElement, fallDist: number, onDone: () => void): void {

--- a/src/style.css
+++ b/src/style.css
@@ -251,11 +251,14 @@
     }
   }
 
-  .octo__placeholder {
+  /* Fixed-dimension slot that holds Octo's layout space even when
+     `.octo` goes `position: fixed` during celebrate/sad animations.
+     Without this, the header flex row collapses and the title
+     jumps left. */
+  .octo-slot {
     flex-shrink: 0;
     width: 3.3125rem;
     height: 3.25rem;
-    display: none;
   }
 
   /* ═══════════════════════════════════════


### PR DESCRIPTION
## Summary
- Wrap \`.octo\` in a fixed-dimension \`.octo-slot\` so the header flex row keeps its space when \`.octo\` goes \`position: fixed\`. Fixes the title sliding left and the vertical re-baseline wobble during celebrate/sad.
- Re-measure the slot at return time instead of using a 5s-old snapshot, so resize/scroll mid-celebration can't desync the landing position.
- Add a 350ms lead-in transition from the header slot to the \`octo-fly\` keyframe's 0% position, so Octo no longer teleports above the logo when celebration starts.
- Remove the broken \`.octo__placeholder\` div and its three placeholder lookups / class toggles.

## Test plan
- [x] Click octo → celebrate: no horizontal title shift, smooth lead-in, no teleport
- [x] Celebrate return: lands cleanly in the slot with no pre-seat drop
- [ ] Sad octo path still works
- [ ] Light + dark themes
- [ ] Mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)