### PR TITLE
Fix duplicate copyright in footer (#176)

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,7 +428,6 @@
             <br />
             &copy; 2026 Jamie &amp; Dave
           </div>
-          <p class="footer__copyright">&copy; 2026 Jamie &amp; Dave</p>
           <div class="dev-links hidden" data-dev-links></div>
         </footer>
       </main>


### PR DESCRIPTION
## Summary
- Removed the unstyled `<p class="footer__copyright">` duplicate in [index.html](index.html)
- The inline `© 2026 Jamie & Dave` inside the "Made with ♥" block is the visible/styled one and stays

Closes #176

## Test plan
- [ ] Footer shows copyright once