### PR TITLE
Replace footer bullet separators with full stops

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,19 +412,18 @@
             </button>
           </div>
           <div class="footer__body" data-foot-body>
-            An experiment in AI-coding with Claude • It's on
+            An experiment in AI-coding with Claude. It's on
             <span class="foot-icon-link">
               <svg width="14" height="14" aria-hidden="true"><use href="/sprites.svg#icon-github"/></svg>
               <a href="https://github.com/jevawin/clumeral-game" target="_blank" rel="noopener" class="text-link">GitHub</a>
-            </span>
-            • Made with
+            </span>. Made with
             <svg class="footer-heart icon-inline" width="18" height="18" aria-hidden="true"><use href="/sprites.svg#icon-heart"/></svg>
             by
             <span class="foot-icon-link">
               <img src="/jamie.webp" alt="Jamie" class="foot-avatar" />
               <a href="https://www.linkedin.com/in/jevawin" target="_blank" rel="noopener noreferrer" class="text-link">Jamie</a>
             </span>
-            and Dave
+            and Dave.
             <br />
             &copy; 2026 Jamie &amp; Dave
           </div>


### PR DESCRIPTION
Swaps the • separators in the footer body for full stops, and adds a full stop after "Made with ♥ by Jamie and Dave".