### PR TITLE
fix: UTC-anchored "today" + SW updates land on first navigation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -95,9 +95,13 @@ let activeBox: number | null = null; // 0 | 1 | 2 | null
 
 // ─── Date helpers ─────────────────────────────────────────────────────────────
 
-function todayLocal() {
+// UTC, not local: the puzzle rolls over at UTC midnight (cron `0 0 * * *`) and
+// puzzleNumber() is anchored to T00:00:00Z. Using the user's local date here
+// would mismatch the server for the duration of the user's UTC offset every
+// night, breaking history lookup and the isArchiveSolve check.
+function todayUTC() {
   const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
 }
 
 function puzzleNumber(dateStr: string): number {
@@ -113,10 +117,10 @@ function formatDate(dateStr: string): string {
   });
 }
 
-// ─── Storage helper (uses todayLocal, stays in app.ts) ───────────────────────
+// ─── Storage helper (uses todayUTC, stays in app.ts) ───────────────────────
 
 function todayEntry() {
-  const today = todayLocal();
+  const today = todayUTC();
   return loadHistory().find((h) => h.date === today) || null;
 }
 
@@ -580,7 +584,7 @@ async function startReplayPuzzle(date: string, num: number, clues: ClueData[]): 
     // ARC-02: pre-render completion view with activeDate so the back-link shape is correct
     // when the user reaches the completion screen via /archive/<date>. The renderCompletion
     // signature accepting opts ships in Plan 06 — this call site depends on that change.
-    renderCompletion(num, entry.tries, false, { activeDate: date, todayLocal: todayLocal() });
+    renderCompletion(num, entry.tries, false, { activeDate: date, todayUTC: todayUTC() });
     return;
   }
 
@@ -651,7 +655,7 @@ async function handleGuess() {
         recordGame(gameState.date, tries, guess);
       }
 
-      const isArchiveSolve = !!gameState.date && gameState.date !== todayLocal();
+      const isArchiveSolve = !!gameState.date && gameState.date !== todayUTC();
 
       if (isArchiveSolve) {
         // Archive solve stays on /archive/<date> the whole way — no /solved hop.
@@ -870,7 +874,7 @@ function initMenu(): void {
 initTheme();
 initColours();
 initMenu();
-initFeedbackModal(todayLocal, puzzleNumber, formatDate);
+initFeedbackModal(todayUTC, puzzleNumber, formatDate);
 
 // Pre-render welcome content so navigate('/welcome') has something to show.
 initWelcome();
@@ -878,7 +882,7 @@ initWelcome();
 // Pre-render completion content if today is already solved (SLV-02 parity).
 const _todayHistoryAtBoot = todayEntry();
 if (_todayHistoryAtBoot) {
-  const _todayDate = todayLocal();
+  const _todayDate = todayUTC();
   const _num = puzzleNumber(_todayDate);
   renderCompletion(_num, _todayHistoryAtBoot.tries, false);
 }
@@ -916,7 +920,7 @@ if (isRandomBoot) {
     // hasData = user has played at least one puzzle. RTE-03 deep-link redirect:
     // a stranger sharing /play with someone who's never played should see /welcome.
     hasData: () => !!localStorage.getItem('dlng_history'),
-    todayLocal,
+    todayUTC,
     todayEntry,
     midInteraction: () => activeBox !== null || submitting,
     onArchiveDate: (date) => {
@@ -957,7 +961,7 @@ document.addEventListener('screens:enter', (e) => {
   // replayDate is only meaningful on /archive/<date>. On /play the puzzle is today's daily, even if
   // gameState still holds a previous archive date because the user navigated without reloading.
   const onArchiveDate = location.pathname.startsWith('/archive/');
-  const replayDate = onArchiveDate && gameState.date && gameState.date !== todayLocal() ? gameState.date : undefined;
+  const replayDate = onArchiveDate && gameState.date && gameState.date !== todayUTC() ? gameState.date : undefined;
   showCompletedState(gameState.tries, replayDate);
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -719,10 +719,18 @@ async function loadPuzzle() {
 // ─── Service worker ───────────────────────────────────────────────────────────
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  // updateViaCache: 'none' makes the browser bypass the HTTP cache when checking
+  // /sw.js for updates, so a new deploy is picked up on the next navigation
+  // instead of waiting up to 24h for the cached SW script to expire.
+  navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' });
   navigator.serviceWorker.addEventListener('message', (e) => {
     if (e.data?.type === 'SW_UPDATED') window.location.reload();
   });
+  // Force an update check whenever the page regains focus — covers PWAs and
+  // long-lived tabs where navigation alone wouldn't trigger one.
+  const checkForUpdate = () => navigator.serviceWorker.getRegistration().then(r => r?.update());
+  window.addEventListener('focus', checkForUpdate);
+  document.addEventListener('visibilitychange', () => { if (!document.hidden) checkForUpdate(); });
 }
 
 // ─── Event listeners (module-level) ───────────────────────────────────────────

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -82,9 +82,11 @@ function computeStats(history: HistoryEntry[]): Stats {
 
 function formatCountdown(isRandom: boolean): string | null {
   if (isRandom) return null;
+  // Count down to the next UTC midnight — that's when the cron generates the
+  // new daily puzzle. Using local midnight here would mislead non-UTC users
+  // (e.g. a UK player at 23:30 BST would see "30m" when it's actually 1h 30m).
   const now = new Date();
-  const midnight = new Date(now);
-  midnight.setHours(24, 0, 0, 0);
+  const midnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
   const msUntil = midnight.getTime() - now.getTime();
   const hours = Math.floor(msUntil / 3600000);
   const minutes = Math.floor((msUntil % 3600000) / 60000);
@@ -102,7 +104,7 @@ function renderStatBox(value: string | number, label: string): string {
   </div>`;
 }
 
-export interface RenderCompletionOpts { activeDate?: string; todayLocal?: string }
+export interface RenderCompletionOpts { activeDate?: string; todayUTC?: string }
 
 export function renderCompletion(
   puzzleNum: number,
@@ -157,8 +159,8 @@ export function renderCompletion(
     const isArchivedOtherDate =
       !isRandom &&
       typeof opts.activeDate === 'string' &&
-      typeof opts.todayLocal === 'string' &&
-      opts.activeDate !== opts.todayLocal;
+      typeof opts.todayUTC === 'string' &&
+      opts.activeDate !== opts.todayUTC;
 
     // Show puzzle: only on today's solved view. Archive solves stay on
     // /archive/<date> and never reach the completion screen, so no Show-puzzle

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -22,7 +22,7 @@ export function showToast(message: string, duration: number = 3000): void {
 // ─── Feedback modal ─────────────────────────────────────────────────────────
 
 export function initFeedbackModal(
-  todayLocal: () => string,
+  todayUTC: () => string,
   puzzleNumber: (dateStr: string) => number,
   formatDate: (dateStr: string) => string,
 ): void {
@@ -100,7 +100,7 @@ export function initFeedbackModal(
     else if (/Android/i.test(ua)) device = /Mobi/i.test(ua) ? "Android Phone" : "Android Tablet";
     else if (/Mobi/i.test(ua)) device = "Mobile";
 
-    const dateStr = todayLocal();
+    const dateStr = todayUTC();
     const pNum = puzzleNumber(dateStr);
 
     return {

--- a/src/route-resolver.ts
+++ b/src/route-resolver.ts
@@ -12,7 +12,7 @@ export type Route =
 export interface ResolveCtx {
   hasData: boolean; // any dlng_* storage key present
   todayEntry: HistoryEntry | null;
-  todayLocal: string; // YYYY-MM-DD
+  todayUTC: string; // YYYY-MM-DD
   midInteraction: boolean; // ignored here; the router uses it for stale-day skip
 }
 
@@ -47,7 +47,7 @@ export function resolveRoute(path: string, ctx: ResolveCtx): Route {
   const m = path.match(ARCHIVE_DATE_RE);
   if (m) {
     const d = m[1];
-    if (!isValidDate(d) || d > ctx.todayLocal) return { kind: 'archive' };
+    if (!isValidDate(d) || d > ctx.todayUTC) return { kind: 'archive' };
     return { kind: 'archive-date', date: d };
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -55,7 +55,7 @@ function routeFromPath(path: string): Route {
 
 interface RouterDeps {
   hasData: () => boolean;
-  todayLocal: () => string;
+  todayUTC: () => string;
   todayEntry: () => HistoryEntry | null;
   midInteraction: () => boolean;
   onArchiveDate?: (date: string) => void;
@@ -69,7 +69,7 @@ function ctx(): ResolveCtx {
   return {
     hasData: deps.hasData(),
     todayEntry: deps.todayEntry(),
-    todayLocal: deps.todayLocal(),
+    todayUTC: deps.todayUTC(),
     midInteraction: deps.midInteraction(),
   };
 }
@@ -144,7 +144,7 @@ function checkStaleDay(): void {
   if (!deps) return;
   // POL-04 + RTE-03: skip mid-interaction.
   if (deps.midInteraction()) return;
-  const real = deps.todayLocal();
+  const real = deps.todayUTC();
   if (real === lastKnownDate) return;
   lastKnownDate = real;
   if (location.pathname === '/solved' && !deps.todayEntry()) {
@@ -160,7 +160,7 @@ const LAST_VISIT_KEY = 'dlng_last_visit_date';
 
 export function initRouter(d: RouterDeps): void {
   deps = d;
-  const today = d.todayLocal();
+  const today = d.todayUTC();
   lastKnownDate = today;
 
   // Cold-load rollover redirect — runs before the first navigate so the user

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -12,9 +12,12 @@ import { navigate } from './router.ts';
 
 const EPOCH_DATE = "2026-03-08";
 
-function todayLocal(): string {
+// UTC, not local — see comment on todayUTC in app.ts. The puzzle's identity is
+// UTC-anchored; mismatching here would surface the wrong puzzleNumber on the
+// welcome screen for the duration of the user's UTC offset every night.
+function todayUTC(): string {
   const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
 }
 
 function puzzleNumber(dateStr: string): number {
@@ -126,7 +129,7 @@ function renderWelcome(): void {
   const screen = document.querySelector('[data-screen="welcome"]') as HTMLElement | null;
   if (!screen) return;
 
-  const today = todayLocal();
+  const today = todayUTC();
   const num = puzzleNumber(today);
   const formattedDate = new Date(today + "T00:00:00").toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" });
   const puzzleNumHtml = num > 0 ? `<p class="text-base text-text text-center">Puzzle #${num} · ${formattedDate}</p>` : "";

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,7 +1,7 @@
 // Worker entry point — serves API routes for puzzle data and guess validation.
 // The answer is never sent to the client.
 
-import { runFilterLoop, makeRng, dateSeedInt, todayLocal, puzzleNumber, puzzleDate } from './puzzle.ts';
+import { runFilterLoop, makeRng, dateSeedInt, todayUTC, puzzleNumber, puzzleDate } from './puzzle.ts';
 import { signToken, verifyToken } from './crypto.ts';
 import { getStats, renderDashboard } from './stats.ts';
 import { renderArchivePage } from './puzzles.ts';
@@ -53,7 +53,7 @@ async function getDailyPuzzle(env: Env, date: string): Promise<StoredPuzzle> {
 // ─── Route handlers ──────────────────────────────────────────────────────────
 
 async function handleGetPuzzle(env: Env): Promise<Response> {
-  const today = todayLocal();
+  const today = todayUTC();
   const puzzle = await getDailyPuzzle(env, today);
   return json({
     date: today,
@@ -98,7 +98,7 @@ async function handleGuess(request: Request, env: Env): Promise<Response> {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
       return json({ error: 'Invalid date format' }, 400);
     }
-    if (body.date > todayLocal()) {
+    if (body.date > todayUTC()) {
       return json({ error: 'Cannot guess future puzzles' }, 400);
     }
     const puzzle = await getDailyPuzzle(env, body.date);
@@ -134,7 +134,7 @@ export default {
       const num = parseInt(puzzleByNum[1], 10);
       if (num < 1) return json({ error: 'Invalid puzzle number' }, 400);
       const date = puzzleDate(num);
-      if (date > todayLocal()) return json({ error: 'Puzzle not available yet' }, 400);
+      if (date > todayUTC()) return json({ error: 'Puzzle not available yet' }, 400);
       const puzzle = await getDailyPuzzle(env, date);
       return json({ date, puzzleNumber: num, clues: puzzle.clues });
     }
@@ -147,7 +147,7 @@ export default {
       const num = parseInt(solutionByNum[1], 10);
       if (num < 1) return json({ error: 'Invalid puzzle number' }, 400);
       const date = puzzleDate(num);
-      if (date >= todayLocal()) return json({ error: 'Solution not available' }, 403);
+      if (date >= todayUTC()) return json({ error: 'Solution not available' }, 403);
       const puzzle = await getDailyPuzzle(env, date);
       return json({ answer: puzzle.answer });
     }
@@ -163,7 +163,7 @@ export default {
         const { answer } = runFilterLoop(rng);
         return json({ answer });
       }
-      const today = todayLocal();
+      const today = todayUTC();
       const puzzle = await getDailyPuzzle(env, today);
       return json({ answer: puzzle.answer });
     }
@@ -233,7 +233,7 @@ export default {
 
     // GET /archive — Worker-rendered archive list (renamed from /puzzles).
     if (request.method === 'GET' && url.pathname === '/archive') {
-      const today = todayLocal();
+      const today = todayUTC();
       const todayNum = puzzleNumber(today);
       const keys = await env.PUZZLES.list();
       const puzzles = await Promise.all(
@@ -313,7 +313,7 @@ export default {
 
   // ── Cron: pre-generate today's puzzle at midnight UTC ──
   async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
-    const today = todayLocal();
+    const today = todayUTC();
     await getDailyPuzzle(env, today);
   },
 };

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -287,6 +287,15 @@ export default {
 
     // ── Static pages ──
 
+    // /sw.js must never sit in any CDN or browser cache or stale deploys would
+    // keep serving the old bundle. Override the asset response's headers.
+    if (request.method === 'GET' && url.pathname === '/sw.js') {
+      const res = await env.ASSETS.fetch(request);
+      const headers = new Headers(res.headers);
+      headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+    }
+
     // GET / and client SPA routes — serve static HTML (client router handles in-page nav).
     if (request.method === 'GET' && (
       url.pathname === '/' ||

--- a/src/worker/puzzle.ts
+++ b/src/worker/puzzle.ts
@@ -181,9 +181,13 @@ export function makeRng(seed: number) {
   };
 }
 
-export function todayLocal() {
+// Named after the puzzle's source of truth (UTC). Workers already run in UTC
+// so getFullYear/getUTCFullYear would return the same value here, but using
+// the UTC methods makes the asymmetry with the browser explicit and matches
+// the renamed client-side helper.
+export function todayUTC() {
   const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 }
 
 export function dateSeedInt(dateStr: string): number {

--- a/tests/completion-links.spec.ts
+++ b/tests/completion-links.spec.ts
@@ -21,7 +21,7 @@ describe('completion links (ARC-02)', () => {
 
   it('ARC-02: /archive/<today> solved view links Show puzzle to in-app handler and Archive to /archive', async () => {
     const mod = await import('../src/completion.ts');
-    mod.renderCompletion(42, 2, false, { activeDate: '2026-05-03', todayLocal: '2026-05-03' });
+    mod.renderCompletion(42, 2, false, { activeDate: '2026-05-03', todayUTC: '2026-05-03' });
 
     const links = document.querySelector('[data-completion-links]')!;
     const showPuzzle = links.querySelector('[data-completion-show-puzzle]') as HTMLAnchorElement | null;
@@ -32,7 +32,7 @@ describe('completion links (ARC-02)', () => {
 
   it('ARC-02: /archive/<other-date> never shows Show puzzle (archive solves stay on /archive/<date>; completion screen is today-only)', async () => {
     const mod = await import('../src/completion.ts');
-    mod.renderCompletion(10, 3, false, { activeDate: '2026-04-01', todayLocal: '2026-05-03' });
+    mod.renderCompletion(10, 3, false, { activeDate: '2026-04-01', todayUTC: '2026-05-03' });
 
     const links = document.querySelector('[data-completion-links]')!;
     const showPuzzle = links.querySelector('[data-completion-show-puzzle]');

--- a/tests/resolve-route.spec.ts
+++ b/tests/resolve-route.spec.ts
@@ -5,7 +5,7 @@ function ctx(over: Partial<ResolveCtx> = {}): ResolveCtx {
   return {
     hasData: true,
     todayEntry: null,
-    todayLocal: '2026-05-03',
+    todayUTC: '2026-05-03',
     midInteraction: false,
     ...over,
   };

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
   // Default deps: data present, no today entry, today=2026-05-03, not mid-interaction.
   initRouter({
     hasData: () => true,
-    todayLocal: () => '2026-05-03',
+    todayUTC: () => '2026-05-03',
     todayEntry: () => null,
     midInteraction: () => false,
   });
@@ -63,7 +63,7 @@ describe('router (RTE-01, POL-01..04)', () => {
     const todayEntry = { date: '2026-05-03', tries: 2 };
     initRouter({
       hasData: () => true,
-      todayLocal: () => '2026-05-03',
+      todayUTC: () => '2026-05-03',
       todayEntry: () => todayEntry,
       midInteraction: () => false,
     });
@@ -92,7 +92,7 @@ describe('router (RTE-01, POL-01..04)', () => {
     const todayEntry = { date: '2026-05-03', tries: 2 };
     initRouter({
       hasData: () => true,
-      todayLocal: () => '2026-05-03',
+      todayUTC: () => '2026-05-03',
       todayEntry: () => todayEntry,
       midInteraction: () => false,
     });
@@ -167,7 +167,7 @@ describe('router (RTE-01, POL-01..04)', () => {
     let now = '2026-05-03';
     initRouter({
       hasData: () => true,
-      todayLocal: () => now,
+      todayUTC: () => now,
       todayEntry: () => null, // stale
       midInteraction: () => true,
     });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,8 @@
       "/archive", "/archive/*",
       "/random",
       "/puzzles", "/puzzles/*",
-      "/api/*", "/stats"
+      "/api/*", "/stats",
+      "/sw.js"
     ]
   },
   "analytics_engine_datasets": [


### PR DESCRIPTION
Closes #205.

Two related fixes that came out of the same investigation. The user reported "deployment isn't picking up my changes — the solved screen has the wrong buttons and refresh wipes the result". After ruling out Cloudflare deploy/cache and SW staleness, the real bug turned out to be a UTC/local-date mismatch on the client.

## Commit 1 — SW updates land on first navigation after a deploy

Belt-and-suspenders so deploys propagate to the user immediately:

- Register `sw.js` with `updateViaCache: 'none'` (otherwise the browser can keep the cached SW for up to 24h before checking for a new one).
- Trigger `registration.update()` on `focus` and `visibilitychange` so long-lived tabs / installed PWAs don't have to navigate to discover a new version.
- Worker rewrites `Cache-Control` on `/sw.js` to `no-cache, no-store, must-revalidate`. Required adding `/sw.js` to `assets.run_worker_first` so the Worker actually intercepts the request.

## Commit 2 — anchor "today" to UTC on the client

The puzzle is UTC-anchored: cron is `0 0 * * *` UTC, `puzzleNumber()` uses `T00:00:00Z`. But `app.ts:todayLocal()` (and the duplicate in `welcome.ts`) returned the *user's local* date. Between local midnight and the next UTC midnight, the two clocks disagree.

For a UK user at 00:30 BST:
- `/api/puzzle` returned `date = "2026-05-10"` (server UTC)
- Client `todayLocal()` returned `"2026-05-11"`
- `isArchiveSolve` at `app.ts:654` evaluated `true` on `/play` → rendered the archive-replay UI (`Archive` solid + `Today` hollow) and skipped `replaceRoute('/solved')` — exactly what the screenshot showed.
- `recordGame` wrote the entry keyed by `gameState.date` (`"2026-05-10"`), but `todayEntry()` looked it up by `todayLocal()` (`"2026-05-11"`) → refresh showed a fresh puzzle.

Fix: rename to `todayUTC()` and use `getUTC*` methods. Mirrored on the server for symmetry (Workers already run in UTC so there's no behaviour change there). Also updated the `completion.ts` countdown to target UTC midnight rather than local midnight — that's when the cron actually fires.

Touches the renamed identifier across `modals.ts`, `welcome.ts`, `router.ts`, `route-resolver.ts`, `RouterDeps`, `ResolveCtx`, `RenderCompletionOpts` and the matching tests.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` — 29/30 pass. The one failing test (`POL-02: navigate(/archive) calls navigator.sendBeacon BEFORE window.location.assign`) is pre-existing on `new-design` HEAD; verified by re-running tests with my changes stashed.
- [x] `npm run build` — clean, `dist/client/sw.js` gets a fresh `CACHE_NAME` per build.
- [ ] On preview: solve today's daily on `/play` between 00:00 and 01:00 BST and confirm redirect to `/solved` with the correct buttons.
- [ ] Refresh after solving, confirm solved state is restored.
- [ ] On `/solved` between 23:30 and 00:00 BST, confirm the countdown reads "Next puzzle in 1h 30m" not "30m".

https://claude.ai/code/session_018GNCqCgBrFrN6BfjXfUhhF