### PR TITLE
First-play octopus walkthrough (#214)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-octopus-walkthrough.md
+++ b/docs/superpowers/plans/2026-05-31-octopus-walkthrough.md
@@ -1,0 +1,637 @@
+# First-Play Octopus Walkthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On a player's first game, the octopus "talks" through the `/play` header — typing a scripted 4-step walkthrough in place of the "Clumeral" wordmark — to teach the core mechanic in context.
+
+**Architecture:** A standalone `src/walkthrough.ts` module owns a small step-machine (current index, active flag, timers) and a brand-text typewriter. It listens for `screens:enter` (trigger), `game:box-opened` and `game:digit-eliminated` (gated-step advance). `app.ts` adds two one-line `CustomEvent` dispatches in `openBox` and `toggleDigit`, plus `import './walkthrough.ts'` at the bottom (side-effect init, like `octo.ts`). The step machine's pure advance logic is unit-testable in isolation.
+
+**Tech Stack:** TypeScript (ES2022), Vite + Cloudflare Workers, Vitest (jsdom) for units, Playwright (vite preview / production build) for e2e.
+
+**Spec:** [docs/superpowers/specs/2026-05-31-octopus-walkthrough-design.md](../specs/2026-05-31-octopus-walkthrough-design.md)
+
+**Merge target:** `new-design` (NOT `staging`/`main`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `index.html:153` | Brand text node — typewriter target | Add `data-brand-text` attr to the `<span>Clumeral</span>` for a clean hook |
+| `index.html` (header) | aria-live announcer | Add a visually-hidden `<span data-walkthrough-live aria-live="polite">` inside the header |
+| `src/walkthrough.ts` | Step machine + typewriter + event wiring | **Create** |
+| `src/app.ts` | Game event dispatches + module init | Modify `openBox`, `toggleDigit`; add import |
+| `tests/walkthrough.spec.ts` | Unit tests for step-machine advance logic | **Create** |
+| `e2e/octopus-walkthrough.spec.ts` | E2E against production build | **Create** |
+
+### Module shape for `src/walkthrough.ts`
+
+Export a pure, testable core plus an init that wires DOM/events:
+
+```ts
+export type StepKind = 'timed' | 'gated' | 'end';
+export type GateEvent = 'game:box-opened' | 'game:digit-eliminated';
+
+export interface Step {
+  kind: StepKind;
+  text: string;
+  gate?: GateEvent; // present iff kind === 'gated'
+}
+
+export const STEPS: Step[]; // the hardcoded 5-entry array (0..4)
+
+// Pure helper — does the given event advance the machine at this index?
+export function gateMatches(step: Step, event: GateEvent): boolean;
+
+// Timing helpers (pure)
+export function holdMsFor(text: string): number;
+export const TYPE_MS = 45;
+export const DELETE_MS = 25;
+
+export function initWalkthrough(): void; // side-effect: wire listeners
+```
+
+`STEPS`:
+
+```ts
+export const STEPS: Step[] = [
+  { kind: 'timed', text: "Looks like it's your first time here…" },
+  { kind: 'timed', text: "The goal: work out the 3-digit number." },
+  { kind: 'gated', text: "Tap one of those big digit boxes to open it…", gate: 'game:box-opened' },
+  { kind: 'gated', text: "Now disable digits it can't be, using the clues.", gate: 'game:digit-eliminated' },
+  { kind: 'end',   text: "" },
+];
+```
+
+`holdMsFor`:
+
+```ts
+export function holdMsFor(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const ms = Math.round((words / 200) * 60_000) + 1000; // 200 wpm + 1s buffer
+  return Math.max(ms, 2000); // 2s floor
+}
+```
+
+---
+
+## Task 1: Add DOM hooks (brand text attr + aria-live region)
+
+**Files:**
+- Modify: `index.html:153` (brand `<span>`) and the header block (`index.html:146-159`)
+
+- [ ] **Step 1: Add `data-brand-text` to the wordmark span**
+
+Change:
+```html
+<span class="text-xl font-bold text-text font-[Comfortaa]">Clumeral</span>
+```
+to:
+```html
+<span data-brand-text class="text-xl font-bold text-text font-[Comfortaa]">Clumeral</span>
+```
+
+- [ ] **Step 2: Add a visually-hidden aria-live region inside the header**
+
+Insert immediately before the closing `</header>` (after the menu button, `index.html` ≈ line 158):
+```html
+<span data-walkthrough-live aria-live="polite" class="sr-only"></span>
+```
+If `sr-only` is not defined in this Tailwind v4 setup, use an inline clip instead:
+```html
+<span data-walkthrough-live aria-live="polite" class="absolute w-px h-px overflow-hidden [clip:rect(0,0,0,0)] whitespace-nowrap border-0 -m-px p-0"></span>
+```
+
+Verify which to use:
+Run: `grep -rn "sr-only" src/tailwind.css index.html`
+If it returns a definition or existing usage, use `sr-only`; else use the inline clip classes.
+
+- [ ] **Step 3: Verify build still compiles**
+
+Run: `npm run build`
+Expected: build succeeds, `dist/` produced, no TS errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add index.html
+git commit -m "feat(214): add brand-text + aria-live hooks for walkthrough"
+```
+
+---
+
+## Task 2: Step-machine core + unit tests (TDD)
+
+**Files:**
+- Create: `src/walkthrough.ts` (core constants/types/pure helpers only in this task)
+- Test: `tests/walkthrough.spec.ts`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/walkthrough.spec.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { STEPS, gateMatches, holdMsFor, TYPE_MS, DELETE_MS } from '../src/walkthrough.ts';
+
+describe('walkthrough step machine', () => {
+  it('has the 4-step flow plus an end step', () => {
+    expect(STEPS).toHaveLength(5);
+    expect(STEPS[0].kind).toBe('timed');
+    expect(STEPS[1].kind).toBe('timed');
+    expect(STEPS[2].kind).toBe('gated');
+    expect(STEPS[3].kind).toBe('gated');
+    expect(STEPS[4].kind).toBe('end');
+  });
+
+  it('gated steps carry the matching game event', () => {
+    expect(STEPS[2].gate).toBe('game:box-opened');
+    expect(STEPS[3].gate).toBe('game:digit-eliminated');
+  });
+
+  it('gateMatches advances only on the step’s own event', () => {
+    expect(gateMatches(STEPS[2], 'game:box-opened')).toBe(true);
+    expect(gateMatches(STEPS[2], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[3], 'game:digit-eliminated')).toBe(true);
+    expect(gateMatches(STEPS[3], 'game:box-opened')).toBe(false);
+  });
+
+  it('gateMatches is false for non-gated steps', () => {
+    expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(false);
+    expect(gateMatches(STEPS[4], 'game:digit-eliminated')).toBe(false);
+  });
+
+  it('holdMsFor: 200 wpm + 1s buffer, 2s floor', () => {
+    expect(holdMsFor('one two three four five six seven')).toBe(Math.max(Math.round((7 / 200) * 60_000) + 1000, 2000));
+    expect(holdMsFor('hi')).toBe(2000); // floor
+    expect(holdMsFor('   ')).toBe(2000); // no words → floor
+  });
+
+  it('type is slower than delete', () => {
+    expect(TYPE_MS).toBe(45);
+    expect(DELETE_MS).toBe(25);
+    expect(DELETE_MS).toBeLessThan(TYPE_MS);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/walkthrough.spec.ts`
+Expected: FAIL — cannot resolve `../src/walkthrough.ts`.
+
+- [ ] **Step 3: Write the minimal core**
+
+Create `src/walkthrough.ts`:
+```ts
+// Clumeral — walkthrough.ts
+// First-play octopus walkthrough: the mascot "talks" through the /play header,
+// typing a scripted tutorial in place of the "Clumeral" wordmark.
+// Frontend-only. No worker/API changes. Triggered on a player's first game
+// (suppressed once `dlng_history` exists). See
+// docs/superpowers/specs/2026-05-31-octopus-walkthrough-design.md.
+
+export type StepKind = 'timed' | 'gated' | 'end';
+export type GateEvent = 'game:box-opened' | 'game:digit-eliminated';
+
+export interface Step {
+  kind: StepKind;
+  text: string;
+  gate?: GateEvent;
+}
+
+export const STEPS: Step[] = [
+  { kind: 'timed', text: "Looks like it's your first time here…" },
+  { kind: 'timed', text: "The goal: work out the 3-digit number." },
+  { kind: 'gated', text: "Tap one of those big digit boxes to open it…", gate: 'game:box-opened' },
+  { kind: 'gated', text: "Now disable digits it can't be, using the clues.", gate: 'game:digit-eliminated' },
+  { kind: 'end',   text: "" },
+];
+
+export const TYPE_MS = 45;
+export const DELETE_MS = 25;
+
+// True iff `event` is the gate this step is waiting on.
+export function gateMatches(step: Step, event: GateEvent): boolean {
+  return step.kind === 'gated' && step.gate === event;
+}
+
+// Reading-time hold: 200 wpm + 1s buffer, 2s floor.
+export function holdMsFor(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const ms = Math.round((words / 200) * 60_000) + 1000;
+  return Math.max(ms, 2000);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/walkthrough.spec.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/walkthrough.ts tests/walkthrough.spec.ts
+git commit -m "feat(214): walkthrough step-machine core + unit tests"
+```
+
+---
+
+## Task 3: Typewriter + runtime wiring (the `initWalkthrough` side-effect)
+
+**Files:**
+- Modify: `src/walkthrough.ts` (append runtime code under the pure core)
+
+This task adds the DOM-driven runtime. It is exercised by the e2e suite (Task 5), not unit tests — it depends on real timers, `requestAnimationFrame`, and layout. Keep all pure logic in the exports from Task 2 so the unit tests stay valid.
+
+- [ ] **Step 1: Append the runtime to `src/walkthrough.ts`**
+
+Add below the pure core:
+```ts
+// ─── Runtime (DOM + timers) ──────────────────────────────────────────────────
+
+const REDUCED_MOTION = () =>
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+
+let active = false;
+let stepIndex = 0;
+let waitingGate: GateEvent | null = null;
+const timers: ReturnType<typeof setTimeout>[] = [];
+
+function later(fn: () => void, ms: number): void {
+  timers.push(setTimeout(fn, ms));
+}
+
+function clearTimers(): void {
+  for (const t of timers) clearTimeout(t);
+  timers.length = 0;
+}
+
+function brandTextEl(): HTMLElement | null {
+  return document.querySelector('[data-brand-text]');
+}
+
+function liveEl(): HTMLElement | null {
+  return document.querySelector('[data-walkthrough-live]');
+}
+
+function announce(text: string): void {
+  const el = liveEl();
+  if (el) el.textContent = text;
+}
+
+function setBrand(text: string): void {
+  const el = brandTextEl();
+  if (el) el.textContent = text;
+}
+
+// Fade the wordmark out (≈250ms), empty it, then run `onDone`.
+function fadeOutWordmark(onDone: () => void): void {
+  const el = brandTextEl();
+  if (!el) { onDone(); return; }
+  if (REDUCED_MOTION()) { el.textContent = ''; onDone(); return; }
+  el.style.transition = 'opacity 0.25s ease-out';
+  el.style.opacity = '0';
+  later(() => {
+    el.textContent = '';
+    el.style.opacity = '1'; // text is empty, so safe to restore opacity now
+    onDone();
+  }, 260);
+}
+
+// Type `text` in char-by-char, then `onDone`. Reduced-motion sets it instantly.
+function typeIn(text: string, onDone: () => void): void {
+  if (REDUCED_MOTION()) { setBrand(text); onDone(); return; }
+  let i = 0;
+  const tick = () => {
+    i++;
+    setBrand(text.slice(0, i));
+    if (i < text.length) later(tick, TYPE_MS);
+    else onDone();
+  };
+  setBrand('');
+  later(tick, TYPE_MS);
+}
+
+// Delete the current brand text char-by-char, then `onDone`.
+function deleteOut(onDone: () => void): void {
+  const el = brandTextEl();
+  const text = el?.textContent ?? '';
+  if (REDUCED_MOTION()) { setBrand(''); onDone(); return; }
+  let i = text.length;
+  const tick = () => {
+    i--;
+    setBrand(text.slice(0, Math.max(i, 0)));
+    if (i > 0) later(tick, DELETE_MS);
+    else onDone();
+  };
+  later(tick, DELETE_MS);
+}
+
+// Restore the wordmark and tear down. Idempotent.
+function finish(): void {
+  if (!active) return;
+  active = false;
+  waitingGate = null;
+  clearTimers();
+  const el = brandTextEl();
+  if (el) { el.style.transition = ''; el.style.opacity = '1'; }
+  setBrand('Clumeral');
+}
+
+function runStep(index: number): void {
+  if (!active) return;
+  stepIndex = index;
+  const step = STEPS[index];
+  if (!step || step.kind === 'end') { finish(); return; }
+
+  announce(step.text);
+  typeIn(step.text, () => {
+    if (step.kind === 'timed') {
+      later(() => deleteOut(() => runStep(index + 1)), holdMsFor(step.text));
+    } else {
+      // gated: hold indefinitely until the matching game event arrives
+      waitingGate = step.gate ?? null;
+    }
+  });
+}
+
+function onGameEvent(event: GateEvent): void {
+  if (!active || waitingGate !== event) return;
+  const step = STEPS[stepIndex];
+  if (!gateMatches(step, event)) return;
+  waitingGate = null;
+  deleteOut(() => runStep(stepIndex + 1));
+}
+
+function start(): void {
+  if (active) return;
+  active = true;
+  stepIndex = 0;
+  waitingGate = null;
+  fadeOutWordmark(() => runStep(0));
+}
+
+export function initWalkthrough(): void {
+  const isNewUser = !localStorage.getItem('dlng_history');
+
+  document.addEventListener('screens:enter', (e) => {
+    const screen = (e as CustomEvent).detail?.screen;
+    if (screen !== 'game') {
+      // Leaving /play mid-sequence reverts the wordmark.
+      if (active) finish();
+      return;
+    }
+    if (isNewUser && !active) start();
+  });
+
+  document.addEventListener('game:box-opened', () => onGameEvent('game:box-opened'));
+  document.addEventListener('game:digit-eliminated', () => onGameEvent('game:digit-eliminated'));
+}
+
+initWalkthrough();
+```
+
+- [ ] **Step 2: Verify it type-checks and builds**
+
+Run: `npm run build`
+Expected: build succeeds, no TS errors.
+
+- [ ] **Step 3: Verify unit tests still pass (pure core unchanged)**
+
+Run: `npx vitest run tests/walkthrough.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/walkthrough.ts
+git commit -m "feat(214): walkthrough typewriter + screen/event runtime"
+```
+
+---
+
+## Task 4: Wire game-event dispatches + module init in `app.ts`
+
+**Files:**
+- Modify: `src/app.ts` — `openBox` (≈ line 421), `toggleDigit` (≈ line 399), and module imports/init
+
+- [ ] **Step 1: Dispatch `game:box-opened` from `openBox`**
+
+In `openBox(i)` (currently ends with `openKeypad();`), add a dispatch after the keypad opens:
+```ts
+function openBox(i: number): void {
+  activeBox = i;
+  // Save active-box selection — daily only (D-06, D-08). Lets restore re-open the right box.
+  if (!gameState.isRandom) saveActive(buildActiveState());
+  renderAllBoxes();
+  buildKeypad();
+  openKeypad();
+  // First-play walkthrough hook (issue #214). No-op once dlng_history exists.
+  document.dispatchEvent(new CustomEvent("game:box-opened"));
+}
+```
+
+- [ ] **Step 2: Dispatch `game:digit-eliminated` from `toggleDigit` (only on elimination)**
+
+The walkthrough's gated step 3 advances when a digit is *removed* (eliminated), not re-added. Dispatch only in the `s.delete(digit)` branch:
+```ts
+function toggleDigit(digit: number): void {
+  if (activeBox === null) return;
+  renderFeedback(null);
+  const s = possibles[activeBox];
+  if (s.has(digit)) {
+    if (s.size === 1) return; // guard: cannot eliminate last digit
+    s.delete(digit);
+    // First-play walkthrough hook (issue #214). Fires only on elimination. No-op once dlng_history exists.
+    document.dispatchEvent(new CustomEvent("game:digit-eliminated"));
+  } else {
+    s.add(digit);
+  }
+  // Save mid-game state after every digit mutation — daily only (D-06, D-08).
+  if (!gameState.isRandom) saveActive(buildActiveState());
+  renderBox(activeBox);
+  buildKeypad();
+  checkSubmit();
+}
+```
+
+- [ ] **Step 3: Import the walkthrough module for side-effect init**
+
+`walkthrough.ts` self-initialises via its trailing `initWalkthrough()` call (matching `octo.ts`). Add the import near the other imports at the top of `app.ts` (after the `./octo.ts` import, line 10):
+```ts
+import './walkthrough.ts';
+```
+
+- [ ] **Step 4: Verify build + units**
+
+Run: `npm run build && npx vitest run`
+Expected: build succeeds; all unit tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app.ts
+git commit -m "feat(214): dispatch game:box-opened + game:digit-eliminated, init walkthrough"
+```
+
+---
+
+## Task 5: E2E against the production build
+
+**Files:**
+- Create: `e2e/octopus-walkthrough.spec.ts`
+
+Notes for the engineer:
+- The suite runs against `vite preview` (production build) — see `playwright.config.ts`. Never disable animations globally.
+- A "new user" = no `dlng_history` in localStorage. Set/clear it via `page.addInitScript` before `goto`.
+- Reach `/play` directly with `page.goto('/play')`. For a new user the router may redirect to `/welcome` (RTE-03 deep-link rule keys off `dlng_history`). The reliable path: go to `/welcome`, click the start control, land on `/play`. Confirm the start control selector first (`grep -n "data-" src/welcome.ts index.html`). If a direct `/play` load shows the walkthrough in practice, prefer it; otherwise drive through `/welcome`.
+- Digit box selector: `[data-digit="0"]`. Keypad digit key: `[data-key="1"]` (avoid the disabled hundreds-place `0`). Brand text: `[data-brand-text]`. Live region: `[data-walkthrough-live]`.
+
+- [ ] **Step 1: Write the e2e spec**
+
+Create `e2e/octopus-walkthrough.spec.ts`:
+```ts
+import { test, expect, type Page } from "@playwright/test";
+
+// E2E for issue #214 — first-play octopus walkthrough.
+// Runs against the PRODUCTION build (vite preview); see playwright.config.ts.
+
+// Navigate a fresh (new-user) session to /play. dlng_history absent → walkthrough runs.
+async function gotoPlayAsNewUser(page: Page): Promise<void> {
+  await page.addInitScript(() => localStorage.removeItem("dlng_history"));
+  await page.goto("/welcome");
+  // Start control on /welcome navigates to /play (welcome.ts:146).
+  await page.locator("[data-start], [data-play], [data-htp-start]").first().click().catch(() => {});
+  // Fallback: if still not on the game screen, hit /play directly.
+  if (!(await page.locator('[data-digit="0"]').isVisible().catch(() => false))) {
+    await page.goto("/play");
+  }
+  await expect(page.locator('[data-digit="0"]')).toBeVisible();
+}
+
+const brand = (p: Page) => p.locator("[data-brand-text]");
+const live = (p: Page) => p.locator("[data-walkthrough-live]");
+
+test("walkthrough types into the header on a first visit", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  // The wordmark leaves "Clumeral" and types a tutorial sentence.
+  await expect(brand(page)).not.toHaveText("Clumeral", { timeout: 10_000 });
+  await expect(brand(page)).toContainText("first time", { timeout: 10_000 });
+});
+
+test("aria-live announces the full sentence per step", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  await expect(live(page)).toContainText("first time", { timeout: 10_000 });
+});
+
+test("gated step 2 advances only after a digit box is opened", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  // Wait for the box-tap prompt (step 2).
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 20_000 });
+  // It should hold on this prompt until we open a box.
+  await page.waitForTimeout(1500);
+  await expect(brand(page)).toContainText("digit boxes");
+  // Open a box → advances to step 3.
+  await page.locator('[data-digit="0"]').click();
+  await expect(brand(page)).toContainText("disable digits", { timeout: 10_000 });
+});
+
+test("gated step 3 advances after a digit is eliminated, then restores the wordmark", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 20_000 });
+  await page.locator('[data-digit="0"]').click();
+  await expect(brand(page)).toContainText("disable digits", { timeout: 10_000 });
+  // Hold until a digit is eliminated.
+  await page.waitForTimeout(1500);
+  await expect(brand(page)).toContainText("disable digits");
+  // Eliminate a digit (key "1" — non-disabled in the hundreds box).
+  await page.locator('[data-key="1"]').click();
+  // Sequence ends → wordmark restored.
+  await expect(brand(page)).toHaveText("Clumeral", { timeout: 10_000 });
+});
+
+test("returning player sees no walkthrough — wordmark from the start", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("dlng_history", JSON.stringify([{ n: 1, t: 3 }])));
+  await page.goto("/play");
+  // Either /play renders or redirects; in all cases the brand stays "Clumeral".
+  await page.waitForTimeout(2000);
+  await expect(brand(page)).toHaveText("Clumeral");
+});
+
+test("prefers-reduced-motion: text appears instantly and still advances", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.addInitScript(() => localStorage.removeItem("dlng_history"));
+  await page.goto("/welcome");
+  await page.locator("[data-start], [data-play], [data-htp-start]").first().click().catch(() => {});
+  if (!(await page.locator('[data-digit="0"]').isVisible().catch(() => false))) {
+    await page.goto("/play");
+  }
+  await expect(page.locator('[data-digit="0"]')).toBeVisible();
+  // Full sentence present immediately (no partial single char).
+  await expect(brand(page)).toContainText("first time", { timeout: 5_000 });
+});
+```
+
+- [ ] **Step 2: Run the e2e suite (builds + serves production)**
+
+Run: `npx playwright test e2e/octopus-walkthrough.spec.ts`
+Expected: all tests pass. If selectors are wrong, fix per the real DOM (the welcome start control and box/key attrs), re-run. Adjust copy assertions if the final copy was reworded during build.
+
+- [ ] **Step 3: Run the full e2e suite to confirm no regression**
+
+Run: `npx playwright test`
+Expected: existing `octo-celebration` tests still pass alongside the new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/octopus-walkthrough.spec.ts
+git commit -m "test(214): e2e walkthrough against production build"
+```
+
+---
+
+## Task 6: Review gates + PR
+
+- [ ] **Step 1: Full verification pass**
+
+Run: `npm run build && npx vitest run && npx playwright test`
+Expected: build clean, all units pass, all e2e pass. Capture output as evidence.
+
+- [ ] **Step 2: DA review (fresh-context subagent)** — per [docs/DA-REVIEW.md](../../DA-REVIEW.md). Touches >1 file and changes `/play` behaviour, so required.
+
+- [ ] **Step 3: Self-review** — per [docs/SELF-REVIEW.md](../../SELF-REVIEW.md).
+
+- [ ] **Step 4: Push branch and open PR into `new-design`**
+
+```bash
+git push -u origin issue/214
+gh pr create --base new-design --title "First-play octopus walkthrough (#214)" --body "..."
+```
+PR body must note the AC divergence (no skip in v1; suppression by first solve) per the spec, and ask the user to update the issue's AC checklist on close. Do NOT merge — the user merges.
+
+---
+
+## Self-Review (against spec)
+
+**Spec coverage:**
+- Trigger first-game-only via `dlng_history` → Task 3 `initWalkthrough` + Task 5 returning-player test. ✓
+- No skip control → nothing added; sequence ends by gated completion. ✓
+- Wordmark revert at sequence end / on leaving `/play` → `finish()` on `end` step and on non-game `screens:enter`. ✓
+- 4-step flow (timed/timed/gated/gated) → `STEPS` (Task 2). ✓
+- Hardcoded array, no config file → `STEPS` in-module. ✓
+- Typewriter type/hold/delete; logo fades out first (no untype) → `fadeOutWordmark` + `typeIn`/`deleteOut` (Task 3). ✓
+- Type 45ms, delete 25ms, hold formula + 2s floor → `TYPE_MS`/`DELETE_MS`/`holdMsFor` (Task 2, unit-tested). ✓
+- `prefers-reduced-motion` instant + still advances → `REDUCED_MOTION` branches + Task 5 test. ✓
+- aria-live full sentence per step, never per-char → `announce()` in `runStep` only; typewriter writes brand text node, not the live region. ✓
+- Two one-line `app.ts` dispatches in `openBox`/`toggleDigit` → Task 4. ✓
+- Standalone module imported from `app.ts` like `octo.ts` → Task 3 trailing init + Task 4 import. ✓
+- E2E against production build covering all listed cases → Task 5. ✓
+- Unit test on step machine → Task 2. ✓
+- PR into `new-design`, AC divergence noted → Task 6. ✓
+
+**Placeholder scan:** PR `--body "..."` in Task 6 is filled at PR time (DA/self-review output feeds it); all code steps contain full code. No TBDs.
+
+**Type consistency:** `GateEvent`, `Step`, `STEPS`, `gateMatches`, `holdMsFor`, `TYPE_MS`, `DELETE_MS`, `initWalkthrough` used consistently across Tasks 2–4 and tests.

--- a/docs/superpowers/specs/2026-05-31-octopus-walkthrough-design.md
+++ b/docs/superpowers/specs/2026-05-31-octopus-walkthrough-design.md
@@ -1,0 +1,119 @@
+# First-play octopus walkthrough — design
+
+**Issue:** [#214](https://github.com/jevawin/clumeral-game/issues/214) · **Date:** 2026-05-31
+**Branch:** `issue/214` (off `new-design`) · **Merge target:** `new-design` (NOT `staging`/`main`)
+
+## Goal
+
+On a player's first game, the octopus mascot "talks" through the `/play` header — typing a short
+scripted walkthrough in place of the "Clumeral" wordmark — to teach the core mechanic in context.
+Frontend-only. No worker/API changes.
+
+## Decisions (resolved open questions)
+
+| Question | Decision |
+|---|---|
+| Trigger | First game only. No idle nudge, no replay-from-menu (deferred past v1). |
+| Persistence | Bound to first game. Suppressor is `dlng_history` existing. No new localStorage key. |
+| Skip control | **None** in v1. Sequence ends by completing the gated steps or by solving. |
+| Wordmark revert | Only at sequence end or on leaving `/play`. No hover/blur revert. |
+| Steps | The issue's 4-step flow, as written. |
+| Message source | Hardcoded array in the module. No config file (YAGNI). |
+| Typewriter | Letters type in, hold, delete (chat-scene effect). Logo fades out first (no untype). |
+
+## Architecture (Approach A — standalone module + event hooks)
+
+New file `src/walkthrough.ts`, imported and initialised from `app.ts` like `octo.ts`.
+
+It owns:
+- the step-machine state (current index, active flag, timers)
+- listeners for `screens:enter`, `game:box-opened`, `game:digit-eliminated`
+- the brand-text typewriter swap and restore
+
+`app.ts` changes are minimal — two one-line `CustomEvent` dispatches following the existing
+pattern (`screens:enter`, `analytics:track`):
+- in `openBox`/`selectBox` (≈ app.ts:417–435) → `document.dispatchEvent(new CustomEvent("game:box-opened"))`
+- in `toggleDigit` after a digit is removed (≈ app.ts:399–415) → `game:digit-eliminated`
+
+No other game logic is touched. The step machine is unit-testable in isolation.
+
+## Step flow
+
+Hardcoded array:
+
+| # | Type | Message | Advances when |
+|---|---|---|---|
+| 0 | timed | "Looks like it's your first time here…" | hold elapses |
+| 1 | timed | "The goal: work out the 3-digit number." | hold elapses |
+| 2 | gated | "Tap one of those big digit boxes to open it…" | `game:box-opened` |
+| 3 | gated | "Now disable digits it can't be, using the clues." | `game:digit-eliminated` |
+| 4 | end | — | restore wordmark, done |
+
+- **Timed** steps: type → hold → delete → next, automatically.
+- **Gated** steps: type → hold (no auto-delete, no advance) until the matching game event → then
+  delete → next. Auto-progression never runs while waiting on the user.
+
+Copy is final-draft, not locked — adjust during build/testing if it reads better.
+
+## Typewriter mechanics
+
+- "Clumeral" fades out (opacity transition ≈ 250ms). No untype. The brand text node is then empty.
+- Each sentence types in char-by-char, holds, deletes char-by-char, then the next types.
+- Type speed **45ms/char**, delete speed **25ms/char** (delete snappier).
+- Hold (reading time):
+  ```
+  holdMs = round(words / 200 * 60_000) + 1000   // 200 wpm + 1s buffer
+  holdMs = max(holdMs, 2000)                     // 2s floor
+  ```
+  Timed sentences (7 words each) → ≈ 3.1s hold. Gated sentences ignore the hold (they wait on the event).
+- `prefers-reduced-motion`: skip type/delete animation entirely, set full text instantly, still hold
+  and advance.
+
+## Header swap + accessibility
+
+- The brand `<span>` ([index.html:153](../../../index.html#L153)) text is the typewriter target.
+- An `aria-live="polite"` region announces the **full sentence once** when each step starts — never
+  letter-by-letter (that would spam screen readers). Typewriter is visual only.
+- Wordmark reverts to "Clumeral" at sequence end and whenever the player leaves `/play`.
+- No new interactive controls, so no new keyboard surface to manage. The brand button keeps its
+  existing `aria-label="Home"` behaviour.
+
+## Trigger + persistence
+
+- On `screens:enter` for the `game` screen: if new user (`!localStorage.getItem("dlng_history")`)
+  → run the walkthrough.
+- The first solve writes `dlng_history` via the existing `recordGame()` — so the walkthrough never
+  shows again. **No new localStorage key needed.**
+- A player who closes/reloads `/play` before solving sees the walkthrough again. Accepted for v1
+  (simpler; teaches until they actually play through).
+
+> Note: this intentionally diverges from issue AC "skippable / skipping persists" — v1 has no skip,
+> and suppression is by first solve. Update the issue's AC checklist accordingly when closing.
+
+## Testing
+
+Playwright e2e against the **production build** (standing project rule):
+- Fresh first visit to `/play` → walkthrough types in the header.
+- Gated step 2 advances only after a digit box is opened.
+- Gated step 3 advances only after a digit is eliminated.
+- After step 3 completes → wordmark shows "Clumeral" again.
+- Returning player (`dlng_history` present) → no walkthrough, wordmark from the start.
+- `aria-live` region receives the full sentence per step.
+- `prefers-reduced-motion` → text appears instantly (no per-char animation), still advances.
+
+Unit test on the step machine (advance logic, timed vs gated) if a JS unit harness exists in the repo.
+
+## Out of scope (deferred past v1)
+
+- Idle re-trigger nudge.
+- Ambient/quirky octopus messages outside the tutorial.
+- Replay-the-walkthrough from the menu.
+- Any skip control.
+
+## Execution notes (for the fresh execute chat)
+
+1. You are on / check out `issue/214` (branched off `new-design`).
+2. Follow review gates (DA review → self-review) before PR — this touches >1 file and changes
+   `/play` behaviour.
+3. PR merges into **`new-design`**, not `staging` or `main`.
+4. This must land before the Playwright QA regression suite is finalised (suite asserts `/play`).

--- a/e2e/octopus-walkthrough.spec.ts
+++ b/e2e/octopus-walkthrough.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// E2E for issue #214 — first-play octopus walkthrough.
+// Runs against the PRODUCTION build (vite preview); see playwright.config.ts.
+//
+// A "new user" = no `dlng_history` in localStorage. The walkthrough types a
+// scripted tutorial into the /play header in place of the "Clumeral" wordmark,
+// then restores it once the gated steps complete.
+
+const brand = (p: Page) => p.locator("[data-brand-text]");
+const live = (p: Page) => p.locator("[data-walkthrough-live]");
+
+// Drive a fresh (new-user) session to /play. dlng_history absent → walkthrough runs.
+// The welcome screen's Play button ([data-play-btn]) navigates to /play (welcome.ts).
+async function gotoPlayAsNewUser(page: Page): Promise<void> {
+  await page.addInitScript(() => localStorage.removeItem("dlng_history"));
+  await page.goto("/welcome");
+  await page.locator("[data-play-btn]").click();
+  await expect(page.locator('[data-digit="0"]')).toBeVisible();
+}
+
+test("walkthrough types into the header on a first visit", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  // The wordmark leaves "Clumeral" and types the first tutorial sentence.
+  await expect(brand(page)).not.toHaveText("Clumeral", { timeout: 10_000 });
+  await expect(brand(page)).toContainText("first time", { timeout: 10_000 });
+});
+
+test("aria-live announces the full sentence per step", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  await expect(live(page)).toContainText("first time", { timeout: 10_000 });
+});
+
+test("gated step 2 holds until a digit box is opened", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  // Wait for the box-tap prompt (step 2).
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 20_000 });
+  // It holds on this prompt — no auto-advance while waiting on the user.
+  await page.waitForTimeout(1500);
+  await expect(brand(page)).toContainText("digit boxes");
+  // Open a box → advances to step 3.
+  await page.locator('[data-digit="0"]').click();
+  await expect(brand(page)).toContainText("disable digits", { timeout: 10_000 });
+});
+
+test("gated step 3 advances after a digit is eliminated, then restores the wordmark", async ({ page }) => {
+  await gotoPlayAsNewUser(page);
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 20_000 });
+  await page.locator('[data-digit="0"]').click();
+  await expect(brand(page)).toContainText("disable digits", { timeout: 10_000 });
+  // Holds until a digit is eliminated.
+  await page.waitForTimeout(1500);
+  await expect(brand(page)).toContainText("disable digits");
+  // Eliminate a digit via the keypad (key "1" is selectable in the hundreds box).
+  await page.locator('[data-key="1"]').click();
+  // Sequence ends → wordmark restored.
+  await expect(brand(page)).toHaveText("Clumeral", { timeout: 10_000 });
+});
+
+test("returning player sees no walkthrough — wordmark from the start", async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem("dlng_history", JSON.stringify([{ n: 1, t: 3 }])),
+  );
+  await page.goto("/play");
+  // Brand never leaves "Clumeral" for a returning player.
+  await page.waitForTimeout(2000);
+  await expect(brand(page)).toHaveText("Clumeral");
+});
+
+test("prefers-reduced-motion: text appears instantly and still advances", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.addInitScript(() => localStorage.removeItem("dlng_history"));
+  await page.goto("/welcome");
+  await page.locator("[data-play-btn]").click();
+  await expect(page.locator('[data-digit="0"]')).toBeVisible();
+  // Full sentence present immediately (no per-char animation).
+  await expect(brand(page)).toContainText("first time", { timeout: 5_000 });
+  // Still reaches the gated box-tap prompt.
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 15_000 });
+});

--- a/e2e/octopus-walkthrough.spec.ts
+++ b/e2e/octopus-walkthrough.spec.ts
@@ -3,9 +3,13 @@ import { test, expect, type Page } from "@playwright/test";
 // E2E for issue #214 — first-play octopus walkthrough.
 // Runs against the PRODUCTION build (vite preview); see playwright.config.ts.
 //
-// A "new user" = no `dlng_history` in localStorage. The walkthrough types a
-// scripted tutorial into the /play header in place of the "Clumeral" wordmark,
-// then restores it once the gated steps complete.
+// A "new user" = no `dlng_history` in localStorage. The walkthrough waits ~5s,
+// then types a scripted tutorial into the /play header in place of the
+// "Clumeral" wordmark, and restores it once the gated steps complete.
+//
+// Script anchors: step 0 (gated, box-opened) = "number box"; after opening a box
+// the timed steps lead to step 3 (gated, digit-eliminated) = "not prime"; the
+// final timed step = "submit"; then the wordmark restores to "Clumeral".
 
 const brand = (p: Page) => p.locator("[data-brand-text]");
 const live = (p: Page) => p.locator("[data-walkthrough-live]");
@@ -21,40 +25,42 @@ async function gotoPlayAsNewUser(page: Page): Promise<void> {
 
 test("walkthrough types into the header on a first visit", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  // The wordmark leaves "Clumeral" and types the first tutorial sentence.
-  await expect(brand(page)).not.toHaveText("Clumeral", { timeout: 10_000 });
-  await expect(brand(page)).toContainText("first time", { timeout: 12_000 });
+  // After the ~5s hold the wordmark leaves "Clumeral" and types step 0.
+  await expect(brand(page)).not.toHaveText("Clumeral", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
 });
 
 test("aria-live announces the full sentence per step", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  await expect(live(page)).toContainText("first time", { timeout: 12_000 });
+  await expect(live(page)).toContainText("number box", { timeout: 12_000 });
 });
 
-test("gated step 2 holds until a digit box is opened", async ({ page }) => {
+test("gated step holds until a digit box is opened", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  // Wait for the box-tap prompt (step 2).
-  await expect(brand(page)).toContainText("digit boxes", { timeout: 32_000 });
+  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
   // It holds on this prompt — no auto-advance while waiting on the user.
   await page.waitForTimeout(1500);
-  await expect(brand(page)).toContainText("digit boxes");
-  // Open a box → advances to step 3.
+  await expect(brand(page)).toContainText("number box");
+  // Open a box → advances to the next (timed) step.
   await page.locator('[data-digit="0"]').click();
-  await expect(brand(page)).toContainText("deselect digits", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("based on the clues", { timeout: 12_000 });
 });
 
-test("gated step 3 advances after a digit is eliminated, then restores the wordmark", async ({ page }) => {
+test("gated step holds for elimination, then restores the wordmark at the end", async ({ page }) => {
+  test.setTimeout(60_000); // full run-through: ~5s hold + 5 scripted steps
   await gotoPlayAsNewUser(page);
-  await expect(brand(page)).toContainText("digit boxes", { timeout: 32_000 });
+  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
   await page.locator('[data-digit="0"]').click();
-  await expect(brand(page)).toContainText("deselect digits", { timeout: 12_000 });
+  // Timed steps auto-advance to the second gated prompt.
+  await expect(brand(page)).toContainText("not prime", { timeout: 25_000 });
   // Holds until a digit is eliminated.
   await page.waitForTimeout(1500);
-  await expect(brand(page)).toContainText("deselect digits");
+  await expect(brand(page)).toContainText("not prime");
   // Eliminate a digit via the keypad (key "1" is selectable in the hundreds box).
   await page.locator('[data-key="1"]').click();
-  // Sequence ends → wordmark restored.
-  await expect(brand(page)).toHaveText("Clumeral", { timeout: 10_000 });
+  // Advances to the final timed step, then ends → wordmark restored.
+  await expect(brand(page)).toContainText("submit", { timeout: 12_000 });
+  await expect(brand(page)).toHaveText("Clumeral", { timeout: 15_000 });
 });
 
 test("returning player sees no walkthrough — wordmark from the start", async ({ page }) => {
@@ -62,8 +68,8 @@ test("returning player sees no walkthrough — wordmark from the start", async (
     localStorage.setItem("dlng_history", JSON.stringify([{ n: 1, t: 3 }])),
   );
   await page.goto("/play");
-  // Brand never leaves "Clumeral" for a returning player.
-  await page.waitForTimeout(2000);
+  // Brand never leaves "Clumeral" for a returning player (well past the 5s start delay).
+  await page.waitForTimeout(7000);
   await expect(brand(page)).toHaveText("Clumeral");
 });
 
@@ -73,8 +79,9 @@ test("prefers-reduced-motion: text appears instantly and still advances", async 
   await page.goto("/welcome");
   await page.locator("[data-play-btn]").click();
   await expect(page.locator('[data-digit="0"]')).toBeVisible();
-  // Full sentence present immediately (no per-char animation).
-  await expect(brand(page)).toContainText("first time", { timeout: 10_000 });
-  // Still reaches the gated box-tap prompt.
-  await expect(brand(page)).toContainText("digit boxes", { timeout: 25_000 });
+  // First gated prompt present (set instantly, no per-char animation).
+  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
+  // Opening a box still advances the machine under reduced motion.
+  await page.locator('[data-digit="0"]').click();
+  await expect(brand(page)).toContainText("based on the clues", { timeout: 12_000 });
 });

--- a/e2e/octopus-walkthrough.spec.ts
+++ b/e2e/octopus-walkthrough.spec.ts
@@ -25,19 +25,21 @@ async function gotoPlayAsNewUser(page: Page): Promise<void> {
 
 test("walkthrough types into the header on a first visit", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  // After the ~5s hold the wordmark leaves "Clumeral" and types step 0.
+  // After the ~5s hold the wordmark leaves "Clumeral" and types the intro.
   await expect(brand(page)).not.toHaveText("Clumeral", { timeout: 12_000 });
-  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("first time", { timeout: 12_000 });
 });
 
 test("aria-live announces the full sentence per step", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  await expect(live(page)).toContainText("number box", { timeout: 12_000 });
+  await expect(live(page)).toContainText("first time", { timeout: 12_000 });
 });
 
 test("gated step holds until a digit box is opened", async ({ page }) => {
+  test.setTimeout(60_000); // two timed intro steps precede the gated prompt
   await gotoPlayAsNewUser(page);
-  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
+  // Intro steps auto-advance to the first gated prompt.
+  await expect(brand(page)).toContainText("number box", { timeout: 30_000 });
   // It holds on this prompt — no auto-advance while waiting on the user.
   await page.waitForTimeout(1500);
   await expect(brand(page)).toContainText("number box");
@@ -47,9 +49,9 @@ test("gated step holds until a digit box is opened", async ({ page }) => {
 });
 
 test("gated step holds for elimination, then restores the wordmark at the end", async ({ page }) => {
-  test.setTimeout(60_000); // full run-through: ~5s hold + 5 scripted steps
+  test.setTimeout(90_000); // full run-through: ~5s hold + 7 scripted steps
   await gotoPlayAsNewUser(page);
-  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("number box", { timeout: 30_000 });
   await page.locator('[data-digit="0"]').click();
   // Timed steps auto-advance to the second gated prompt.
   await expect(brand(page)).toContainText("not prime", { timeout: 25_000 });
@@ -74,13 +76,15 @@ test("returning player sees no walkthrough — wordmark from the start", async (
 });
 
 test("prefers-reduced-motion: text appears instantly and still advances", async ({ page }) => {
+  test.setTimeout(60_000); // two timed intro steps precede the gated prompt
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.addInitScript(() => localStorage.removeItem("dlng_history"));
   await page.goto("/welcome");
   await page.locator("[data-play-btn]").click();
   await expect(page.locator('[data-digit="0"]')).toBeVisible();
-  // First gated prompt present (set instantly, no per-char animation).
-  await expect(brand(page)).toContainText("number box", { timeout: 12_000 });
+  // Intro text set instantly (no per-char animation), still auto-advances.
+  await expect(brand(page)).toContainText("first time", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("number box", { timeout: 30_000 });
   // Opening a box still advances the machine under reduced motion.
   await page.locator('[data-digit="0"]').click();
   await expect(brand(page)).toContainText("based on the clues", { timeout: 12_000 });

--- a/e2e/octopus-walkthrough.spec.ts
+++ b/e2e/octopus-walkthrough.spec.ts
@@ -23,34 +23,34 @@ test("walkthrough types into the header on a first visit", async ({ page }) => {
   await gotoPlayAsNewUser(page);
   // The wordmark leaves "Clumeral" and types the first tutorial sentence.
   await expect(brand(page)).not.toHaveText("Clumeral", { timeout: 10_000 });
-  await expect(brand(page)).toContainText("first time", { timeout: 10_000 });
+  await expect(brand(page)).toContainText("first time", { timeout: 12_000 });
 });
 
 test("aria-live announces the full sentence per step", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  await expect(live(page)).toContainText("first time", { timeout: 10_000 });
+  await expect(live(page)).toContainText("first time", { timeout: 12_000 });
 });
 
 test("gated step 2 holds until a digit box is opened", async ({ page }) => {
   await gotoPlayAsNewUser(page);
   // Wait for the box-tap prompt (step 2).
-  await expect(brand(page)).toContainText("digit boxes", { timeout: 20_000 });
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 32_000 });
   // It holds on this prompt — no auto-advance while waiting on the user.
   await page.waitForTimeout(1500);
   await expect(brand(page)).toContainText("digit boxes");
   // Open a box → advances to step 3.
   await page.locator('[data-digit="0"]').click();
-  await expect(brand(page)).toContainText("disable digits", { timeout: 10_000 });
+  await expect(brand(page)).toContainText("deselect digits", { timeout: 12_000 });
 });
 
 test("gated step 3 advances after a digit is eliminated, then restores the wordmark", async ({ page }) => {
   await gotoPlayAsNewUser(page);
-  await expect(brand(page)).toContainText("digit boxes", { timeout: 20_000 });
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 32_000 });
   await page.locator('[data-digit="0"]').click();
-  await expect(brand(page)).toContainText("disable digits", { timeout: 10_000 });
+  await expect(brand(page)).toContainText("deselect digits", { timeout: 12_000 });
   // Holds until a digit is eliminated.
   await page.waitForTimeout(1500);
-  await expect(brand(page)).toContainText("disable digits");
+  await expect(brand(page)).toContainText("deselect digits");
   // Eliminate a digit via the keypad (key "1" is selectable in the hundreds box).
   await page.locator('[data-key="1"]').click();
   // Sequence ends → wordmark restored.
@@ -74,7 +74,7 @@ test("prefers-reduced-motion: text appears instantly and still advances", async 
   await page.locator("[data-play-btn]").click();
   await expect(page.locator('[data-digit="0"]')).toBeVisible();
   // Full sentence present immediately (no per-char animation).
-  await expect(brand(page)).toContainText("first time", { timeout: 5_000 });
+  await expect(brand(page)).toContainText("first time", { timeout: 10_000 });
   // Still reaches the gated box-tap prompt.
-  await expect(brand(page)).toContainText("digit boxes", { timeout: 15_000 });
+  await expect(brand(page)).toContainText("digit boxes", { timeout: 25_000 });
 });

--- a/e2e/octopus-walkthrough.spec.ts
+++ b/e2e/octopus-walkthrough.spec.ts
@@ -7,12 +7,15 @@ import { test, expect, type Page } from "@playwright/test";
 // then types a scripted tutorial into the /play header in place of the
 // "Clumeral" wordmark, and restores it once the gated steps complete.
 //
-// Script anchors: step 0 (gated, box-opened) = "number box"; after opening a box
-// the timed steps lead to step 3 (gated, digit-eliminated) = "not prime"; the
-// final timed step = "submit"; then the wordmark restores to "Clumeral".
+// Script anchors: intro = "first time"; first gated (box-opened) = "number box";
+// after opening a box, timed steps lead to the second gated (digit-eliminated) =
+// "remove it"; the final timed step = "submit"; then it restores to "Clumeral".
+// While talking the header is pinned (position: sticky) and reverts on finish.
 
 const brand = (p: Page) => p.locator("[data-brand-text]");
 const live = (p: Page) => p.locator("[data-walkthrough-live]");
+const headerPosition = (p: Page) =>
+  p.locator("[data-app-header]").evaluate((el) => getComputedStyle(el).position);
 
 // Drive a fresh (new-user) session to /play. dlng_history absent → walkthrough runs.
 // The welcome screen's Play button ([data-play-btn]) navigates to /play (welcome.ts).
@@ -43,9 +46,11 @@ test("gated step holds until a digit box is opened", async ({ page }) => {
   // It holds on this prompt — no auto-advance while waiting on the user.
   await page.waitForTimeout(1500);
   await expect(brand(page)).toContainText("number box");
+  // Header is pinned (sticky) while the octopus is talking.
+  expect(await headerPosition(page)).toBe("sticky");
   // Open a box → advances to the next (timed) step.
   await page.locator('[data-digit="0"]').click();
-  await expect(brand(page)).toContainText("based on the clues", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("prime", { timeout: 12_000 });
 });
 
 test("gated step holds for elimination, then restores the wordmark at the end", async ({ page }) => {
@@ -54,15 +59,17 @@ test("gated step holds for elimination, then restores the wordmark at the end", 
   await expect(brand(page)).toContainText("number box", { timeout: 30_000 });
   await page.locator('[data-digit="0"]').click();
   // Timed steps auto-advance to the second gated prompt.
-  await expect(brand(page)).toContainText("not prime", { timeout: 25_000 });
+  await expect(brand(page)).toContainText("remove it", { timeout: 25_000 });
   // Holds until a digit is eliminated.
   await page.waitForTimeout(1500);
-  await expect(brand(page)).toContainText("not prime");
+  await expect(brand(page)).toContainText("remove it");
   // Eliminate a digit via the keypad (key "1" is selectable in the hundreds box).
   await page.locator('[data-key="1"]').click();
   // Advances to the final timed step, then ends → wordmark restored.
   await expect(brand(page)).toContainText("submit", { timeout: 12_000 });
   await expect(brand(page)).toHaveText("Clumeral", { timeout: 15_000 });
+  // Header reverts to its static position once the walkthrough finishes.
+  expect(await headerPosition(page)).not.toBe("sticky");
 });
 
 test("returning player sees no walkthrough — wordmark from the start", async ({ page }) => {
@@ -87,5 +94,5 @@ test("prefers-reduced-motion: text appears instantly and still advances", async 
   await expect(brand(page)).toContainText("number box", { timeout: 30_000 });
   // Opening a box still advances the machine under reduced motion.
   await page.locator('[data-digit="0"]').click();
-  await expect(brand(page)).toContainText("based on the clues", { timeout: 12_000 });
+  await expect(brand(page)).toContainText("prime", { timeout: 12_000 });
 });

--- a/e2e/octopus-walkthrough.spec.ts
+++ b/e2e/octopus-walkthrough.spec.ts
@@ -48,6 +48,8 @@ test("gated step holds until a digit box is opened", async ({ page }) => {
   await expect(brand(page)).toContainText("number box");
   // Header is pinned (sticky) while the octopus is talking.
   expect(await headerPosition(page)).toBe("sticky");
+  // The "Tap a number box" lead is rendered bold (a <strong> inside the brand).
+  await expect(page.locator("[data-brand-text] strong")).toHaveText("Tap a number box");
   // Open a box → advances to the next (timed) step.
   await page.locator('[data-digit="0"]').click();
   await expect(brand(page)).toContainText("prime", { timeout: 12_000 });

--- a/index.html
+++ b/index.html
@@ -150,8 +150,9 @@
             <circle cx="33" cy="15" r="2.5" fill="#F6F0E8"/>
             <path d="M21 26C24.3333 27.3333 27.6667 27.3333 31 26" stroke="#F6F0E8" stroke-width="1.5" stroke-linecap="round"/>
           </svg>
-          <span class="text-xl font-bold text-text font-[Comfortaa]">Clumeral</span>
+          <span data-brand-text class="text-xl font-bold text-text font-[Comfortaa]">Clumeral</span>
         </button>
+        <span data-walkthrough-live aria-live="polite" class="sr-only"></span>
         <button data-menu-btn class="burger-btn relative h-10 w-10 flex items-center justify-center text-text -mr-[10px]" type="button" aria-expanded="false" aria-controls="app-menu" aria-label="Open menu">
           <span aria-hidden="true" class="burger-bar"></span>
           <span aria-hidden="true" class="burger-bar"></span>

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { initTheme } from './theme.ts';
 import { initColours } from './colours.ts';
 import { initFeedbackModal } from './modals.ts';
 import { celebrateOcto, sadOcto } from './octo.ts';
+import './walkthrough.ts';
 import { showScreen } from './screens.ts';
 import { navigate, replaceRoute, initRouter } from './router.ts';
 import { initWelcome } from './welcome.ts';
@@ -403,6 +404,8 @@ function toggleDigit(digit: number): void {
   if (s.has(digit)) {
     if (s.size === 1) return; // guard: cannot eliminate last digit
     s.delete(digit);
+    // First-play walkthrough hook (issue #214). Fires only on elimination. No-op once dlng_history exists.
+    document.dispatchEvent(new CustomEvent("game:digit-eliminated"));
   } else {
     s.add(digit);
   }
@@ -421,6 +424,8 @@ function openBox(i: number): void {
   renderAllBoxes();
   buildKeypad();
   openKeypad();
+  // First-play walkthrough hook (issue #214). No-op once dlng_history exists.
+  document.dispatchEvent(new CustomEvent("game:box-opened"));
 }
 
 // Called by click: toggles same box closed, otherwise switches to new box

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -45,6 +45,8 @@ const REDUCED_MOTION = () =>
 let active = false;
 let stepIndex = 0;
 let waitingGate: GateEvent | null = null;
+let typing = false;
+let pendingGateHit = false;
 const timers: ReturnType<typeof setTimeout>[] = [];
 
 function later(fn: () => void, ms: number): void {
@@ -137,6 +139,8 @@ function finish(): void {
   if (!active) return;
   active = false;
   waitingGate = null;
+  typing = false;
+  pendingGateHit = false;
   clearTimers();
   const el = brandTextEl();
   if (el) {
@@ -156,13 +160,23 @@ function runStep(index: number): void {
   }
 
   announce(step.text);
+  // Arm the gate BEFORE typing so a fast tap during the type-in is not lost.
+  if (step.kind === 'gated') {
+    waitingGate = step.gate ?? null;
+    pendingGateHit = false;
+  }
+  typing = true;
   typeIn(step.text, () => {
+    typing = false;
     if (step.kind === 'timed') {
       later(() => deleteOut(() => runStep(index + 1)), holdMsFor(step.text));
-    } else {
-      // gated: hold indefinitely until the matching game event arrives
-      waitingGate = step.gate ?? null;
+    } else if (pendingGateHit) {
+      // The user triggered the gate while the prompt was still typing — advance now.
+      pendingGateHit = false;
+      waitingGate = null;
+      deleteOut(() => runStep(index + 1));
     }
+    // else gated: hold until the matching game event arrives (onGameEvent).
   });
 }
 
@@ -170,6 +184,11 @@ function onGameEvent(event: GateEvent): void {
   if (!active || waitingGate !== event) return;
   const step = STEPS[stepIndex];
   if (!gateMatches(step, event)) return;
+  if (typing) {
+    // Event arrived mid-type; advance as soon as the prompt finishes typing.
+    pendingGateHit = true;
+    return;
+  }
   waitingGate = null;
   deleteOut(() => runStep(stepIndex + 1));
 }
@@ -179,6 +198,8 @@ function start(): void {
   active = true;
   stepIndex = 0;
   waitingGate = null;
+  typing = false;
+  pendingGateHit = false;
   fadeOutWordmark(() => runStep(0));
 }
 

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -43,6 +43,7 @@ const REDUCED_MOTION = () =>
   window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
 
 let active = false;
+let hasRun = false;
 let stepIndex = 0;
 let waitingGate: GateEvent | null = null;
 let typing = false;
@@ -146,6 +147,7 @@ function finish(): void {
   if (el) {
     el.style.transition = '';
     el.style.opacity = '1';
+    el.removeAttribute('aria-hidden');
   }
   setBrand('Clumeral');
 }
@@ -200,12 +202,14 @@ function start(): void {
   waitingGate = null;
   typing = false;
   pendingGateHit = false;
+  // Hide the typed prose from the a11y tree — the [data-walkthrough-live] region
+  // is the spoken channel. Prevents a Label-in-Name mismatch on the brand button
+  // (its aria-label stays "Home" while the visible text becomes tutorial prose).
+  brandTextEl()?.setAttribute('aria-hidden', 'true');
   fadeOutWordmark(() => runStep(0));
 }
 
 export function initWalkthrough(): void {
-  const isNewUser = !localStorage.getItem('dlng_history');
-
   document.addEventListener('screens:enter', (e) => {
     const screen = (e as CustomEvent).detail?.screen;
     if (screen !== 'game') {
@@ -213,7 +217,13 @@ export function initWalkthrough(): void {
       if (active) finish();
       return;
     }
-    if (isNewUser && !active) start();
+    // Read `dlng_history` live (not a load-time snapshot) so the walkthrough never
+    // replays once the player has solved a puzzle. `hasRun` latches it to once per
+    // page session — re-navigating game→welcome→game won't re-trigger it.
+    if (!active && !hasRun && !localStorage.getItem('dlng_history')) {
+      hasRun = true;
+      start();
+    }
   });
 
   document.addEventListener('game:box-opened', () => onGameEvent('game:box-opened'));

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -37,9 +37,10 @@ export const HOLD_FACTOR_MOTION = 0.75;
 export const HOLD_FACTOR_REDUCED = 1.25;
 // Hold on the normal logo for a beat before the octopus starts talking.
 export const START_DELAY_MS = 5000;
-// While talking, the brand text drops to clue size (16px), left-aligned, in the
-// clue font (Quicksand), in the theme accent colour — not the bold Comfortaa wordmark.
-const WALKTHROUGH_CLASS = 'text-base font-normal text-accent font-[Quicksand] text-left leading-tight';
+// While talking, the brand text drops to clue size (16px), bold, left-aligned, in
+// the clue font (Quicksand) and theme accent colour — not the Comfortaa wordmark.
+// The action lead (boldPrefix) is rendered bold + italic to stand apart.
+const WALKTHROUGH_CLASS = 'text-base font-bold text-accent font-[Quicksand] text-left leading-tight';
 
 // True iff `event` is the gate this step is waiting on.
 export function gateMatches(step: Step, event: GateEvent): boolean {
@@ -126,9 +127,9 @@ function paintBrand(text: string, i: number, boldPrefix?: string): void {
   if (!boldPrefix) { el.textContent = visible; return; }
   const bLen = boldPrefix.length;
   if (i <= bLen) {
-    el.innerHTML = `<strong class="font-bold">${visible}</strong>`;
+    el.innerHTML = `<strong class="font-bold italic">${visible}</strong>`;
   } else {
-    el.innerHTML = `<strong class="font-bold">${text.slice(0, bLen)}</strong>${text.slice(bLen, i)}`;
+    el.innerHTML = `<strong class="font-bold italic">${text.slice(0, bLen)}</strong>${text.slice(bLen, i)}`;
   }
 }
 

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -12,16 +12,18 @@ export interface Step {
   kind: StepKind;
   text: string;
   gate?: GateEvent;
+  // Leading substring of `text` to render bold (must be a prefix of `text`).
+  boldPrefix?: string;
 }
 
 export const STEPS: Step[] = [
   { kind: 'timed', text: "Looks like it's your first time here…" },
-  { kind: 'timed', text: 'Goal: work out the number from 100–999…' },
-  { kind: 'gated', text: 'Tap a number box to begin…', gate: 'game:box-opened' },
+  { kind: 'timed', text: 'Work out the number from 100–999…' },
+  { kind: 'gated', text: 'Tap a number box to begin…', gate: 'game:box-opened', boldPrefix: 'Tap a number box' },
   { kind: 'timed', text: "Example: clue says 'is a prime number'…" },
   { kind: 'timed', text: 'Remove 0, 1, 4, 6, 8, 9 (not primes)…' },
-  { kind: 'gated', text: 'Tap a number to remove it…', gate: 'game:digit-eliminated' },
-  { kind: 'timed', text: 'Go until you have three left…' },
+  { kind: 'gated', text: 'Tap a number to remove it…', gate: 'game:digit-eliminated', boldPrefix: 'Tap a number' },
+  { kind: 'timed', text: 'Go until each box has one number…' },
   { kind: 'timed', text: 'Then submit your answer 💪' },
   { kind: 'end', text: '' },
 ];
@@ -113,6 +115,23 @@ function setBrand(text: string): void {
   if (el) el.textContent = text;
 }
 
+// Paint the first `i` chars of `text` into the brand node, rendering any leading
+// `boldPrefix` chars inside a <strong>. All step text is hardcoded (no HTML
+// metacharacters), so innerHTML here is not an injection surface.
+function paintBrand(text: string, i: number, boldPrefix?: string): void {
+  const el = brandTextEl();
+  if (!el) return;
+  const visible = text.slice(0, Math.max(i, 0));
+  if (!visible) { el.textContent = ''; return; }
+  if (!boldPrefix) { el.textContent = visible; return; }
+  const bLen = boldPrefix.length;
+  if (i <= bLen) {
+    el.innerHTML = `<strong class="font-bold">${visible}</strong>`;
+  } else {
+    el.innerHTML = `<strong class="font-bold">${text.slice(0, bLen)}</strong>${text.slice(bLen, i)}`;
+  }
+}
+
 // Fade the wordmark out (≈250ms), empty it, then run `onDone`.
 function fadeOutWordmark(onDone: () => void): void {
   const el = brandTextEl();
@@ -135,27 +154,25 @@ function fadeOutWordmark(onDone: () => void): void {
 }
 
 // Type `text` in char-by-char, then `onDone`. Reduced-motion sets it instantly.
-function typeIn(text: string, onDone: () => void): void {
+function typeIn(text: string, boldPrefix: string | undefined, onDone: () => void): void {
   if (REDUCED_MOTION()) {
-    setBrand(text);
+    paintBrand(text, text.length, boldPrefix);
     onDone();
     return;
   }
   let i = 0;
   const tick = () => {
     i++;
-    setBrand(text.slice(0, i));
+    paintBrand(text, i, boldPrefix);
     if (i < text.length) later(tick, TYPE_MS);
     else onDone();
   };
-  setBrand('');
+  paintBrand(text, 0, boldPrefix);
   later(tick, TYPE_MS);
 }
 
-// Delete the current brand text char-by-char, then `onDone`.
-function deleteOut(onDone: () => void): void {
-  const el = brandTextEl();
-  const text = el?.textContent ?? '';
+// Delete `text` char-by-char, then `onDone`.
+function deleteOut(text: string, boldPrefix: string | undefined, onDone: () => void): void {
   if (REDUCED_MOTION()) {
     setBrand('');
     onDone();
@@ -164,7 +181,7 @@ function deleteOut(onDone: () => void): void {
   let i = text.length;
   const tick = () => {
     i--;
-    setBrand(text.slice(0, Math.max(i, 0)));
+    paintBrand(text, i, boldPrefix);
     if (i > 0) later(tick, DELETE_MS);
     else onDone();
   };
@@ -206,16 +223,19 @@ function runStep(index: number): void {
     pendingGateHit = false;
   }
   typing = true;
-  typeIn(step.text, () => {
+  typeIn(step.text, step.boldPrefix, () => {
     typing = false;
     if (step.kind === 'timed') {
       const factor = REDUCED_MOTION() ? HOLD_FACTOR_REDUCED : HOLD_FACTOR_MOTION;
-      later(() => deleteOut(() => runStep(index + 1)), Math.round(holdMsFor(step.text) * factor));
+      later(
+        () => deleteOut(step.text, step.boldPrefix, () => runStep(index + 1)),
+        Math.round(holdMsFor(step.text) * factor),
+      );
     } else if (pendingGateHit) {
       // The user triggered the gate while the prompt was still typing — advance now.
       pendingGateHit = false;
       waitingGate = null;
-      deleteOut(() => runStep(index + 1));
+      deleteOut(step.text, step.boldPrefix, () => runStep(index + 1));
     }
     // else gated: hold until the matching game event arrives (onGameEvent).
   });
@@ -231,7 +251,7 @@ function onGameEvent(event: GateEvent): void {
     return;
   }
   waitingGate = null;
-  deleteOut(() => runStep(stepIndex + 1));
+  deleteOut(step.text, step.boldPrefix, () => runStep(stepIndex + 1));
 }
 
 function start(): void {

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -1,0 +1,38 @@
+// Clumeral — walkthrough.ts
+// First-play octopus walkthrough: the mascot "talks" through the /play header,
+// typing a scripted tutorial in place of the "Clumeral" wordmark.
+// Frontend-only. No worker/API changes. Triggered on a player's first game
+// (suppressed once `dlng_history` exists). See
+// docs/superpowers/specs/2026-05-31-octopus-walkthrough-design.md.
+
+export type StepKind = 'timed' | 'gated' | 'end';
+export type GateEvent = 'game:box-opened' | 'game:digit-eliminated';
+
+export interface Step {
+  kind: StepKind;
+  text: string;
+  gate?: GateEvent;
+}
+
+export const STEPS: Step[] = [
+  { kind: 'timed', text: "Looks like it's your first time here…" },
+  { kind: 'timed', text: 'The goal: work out the 3-digit number.' },
+  { kind: 'gated', text: 'Tap one of those big digit boxes to open it…', gate: 'game:box-opened' },
+  { kind: 'gated', text: "Now disable digits it can't be, using the clues.", gate: 'game:digit-eliminated' },
+  { kind: 'end', text: '' },
+];
+
+export const TYPE_MS = 45;
+export const DELETE_MS = 25;
+
+// True iff `event` is the gate this step is waiting on.
+export function gateMatches(step: Step, event: GateEvent): boolean {
+  return step.kind === 'gated' && step.gate === event;
+}
+
+// Reading-time hold: 200 wpm + 1s buffer, 2s floor.
+export function holdMsFor(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const ms = Math.round((words / 200) * 60_000) + 1000;
+  return Math.max(ms, 2000);
+}

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -36,3 +36,167 @@ export function holdMsFor(text: string): number {
   const ms = Math.round((words / 200) * 60_000) + 1000;
   return Math.max(ms, 2000);
 }
+
+// ─── Runtime (DOM + timers) ──────────────────────────────────────────────────
+
+const REDUCED_MOTION = () =>
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+
+let active = false;
+let stepIndex = 0;
+let waitingGate: GateEvent | null = null;
+const timers: ReturnType<typeof setTimeout>[] = [];
+
+function later(fn: () => void, ms: number): void {
+  timers.push(setTimeout(fn, ms));
+}
+
+function clearTimers(): void {
+  for (const t of timers) clearTimeout(t);
+  timers.length = 0;
+}
+
+function brandTextEl(): HTMLElement | null {
+  return document.querySelector('[data-brand-text]');
+}
+
+function liveEl(): HTMLElement | null {
+  return document.querySelector('[data-walkthrough-live]');
+}
+
+function announce(text: string): void {
+  const el = liveEl();
+  if (el) el.textContent = text;
+}
+
+function setBrand(text: string): void {
+  const el = brandTextEl();
+  if (el) el.textContent = text;
+}
+
+// Fade the wordmark out (≈250ms), empty it, then run `onDone`.
+function fadeOutWordmark(onDone: () => void): void {
+  const el = brandTextEl();
+  if (!el) {
+    onDone();
+    return;
+  }
+  if (REDUCED_MOTION()) {
+    el.textContent = '';
+    onDone();
+    return;
+  }
+  el.style.transition = 'opacity 0.25s ease-out';
+  el.style.opacity = '0';
+  later(() => {
+    el.textContent = '';
+    el.style.opacity = '1'; // text is empty, so safe to restore opacity now
+    onDone();
+  }, 260);
+}
+
+// Type `text` in char-by-char, then `onDone`. Reduced-motion sets it instantly.
+function typeIn(text: string, onDone: () => void): void {
+  if (REDUCED_MOTION()) {
+    setBrand(text);
+    onDone();
+    return;
+  }
+  let i = 0;
+  const tick = () => {
+    i++;
+    setBrand(text.slice(0, i));
+    if (i < text.length) later(tick, TYPE_MS);
+    else onDone();
+  };
+  setBrand('');
+  later(tick, TYPE_MS);
+}
+
+// Delete the current brand text char-by-char, then `onDone`.
+function deleteOut(onDone: () => void): void {
+  const el = brandTextEl();
+  const text = el?.textContent ?? '';
+  if (REDUCED_MOTION()) {
+    setBrand('');
+    onDone();
+    return;
+  }
+  let i = text.length;
+  const tick = () => {
+    i--;
+    setBrand(text.slice(0, Math.max(i, 0)));
+    if (i > 0) later(tick, DELETE_MS);
+    else onDone();
+  };
+  later(tick, DELETE_MS);
+}
+
+// Restore the wordmark and tear down. Idempotent.
+function finish(): void {
+  if (!active) return;
+  active = false;
+  waitingGate = null;
+  clearTimers();
+  const el = brandTextEl();
+  if (el) {
+    el.style.transition = '';
+    el.style.opacity = '1';
+  }
+  setBrand('Clumeral');
+}
+
+function runStep(index: number): void {
+  if (!active) return;
+  stepIndex = index;
+  const step = STEPS[index];
+  if (!step || step.kind === 'end') {
+    finish();
+    return;
+  }
+
+  announce(step.text);
+  typeIn(step.text, () => {
+    if (step.kind === 'timed') {
+      later(() => deleteOut(() => runStep(index + 1)), holdMsFor(step.text));
+    } else {
+      // gated: hold indefinitely until the matching game event arrives
+      waitingGate = step.gate ?? null;
+    }
+  });
+}
+
+function onGameEvent(event: GateEvent): void {
+  if (!active || waitingGate !== event) return;
+  const step = STEPS[stepIndex];
+  if (!gateMatches(step, event)) return;
+  waitingGate = null;
+  deleteOut(() => runStep(stepIndex + 1));
+}
+
+function start(): void {
+  if (active) return;
+  active = true;
+  stepIndex = 0;
+  waitingGate = null;
+  fadeOutWordmark(() => runStep(0));
+}
+
+export function initWalkthrough(): void {
+  const isNewUser = !localStorage.getItem('dlng_history');
+
+  document.addEventListener('screens:enter', (e) => {
+    const screen = (e as CustomEvent).detail?.screen;
+    if (screen !== 'game') {
+      // Leaving /play mid-sequence reverts the wordmark.
+      if (active) finish();
+      return;
+    }
+    if (isNewUser && !active) start();
+  });
+
+  document.addEventListener('game:box-opened', () => onGameEvent('game:box-opened'));
+  document.addEventListener('game:digit-eliminated', () => onGameEvent('game:digit-eliminated'));
+}
+
+initWalkthrough();

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -18,12 +18,17 @@ export const STEPS: Step[] = [
   { kind: 'timed', text: "Looks like it's your first time here…" },
   { kind: 'timed', text: 'The goal: work out the 3-digit number.' },
   { kind: 'gated', text: 'Tap one of those big digit boxes to open it…', gate: 'game:box-opened' },
-  { kind: 'gated', text: "Now disable digits it can't be, using the clues.", gate: 'game:digit-eliminated' },
+  { kind: 'gated', text: "Now deselect digits it can't be using the clues", gate: 'game:digit-eliminated' },
   { kind: 'end', text: '' },
 ];
 
 export const TYPE_MS = 45;
 export const DELETE_MS = 25;
+// Hold on the normal logo for a beat before the octopus starts talking.
+export const START_DELAY_MS = 5000;
+// While talking, the brand text drops to clue size (16px), left-aligned, in the
+// clue font (Quicksand) — not the bold Comfortaa wordmark size.
+const WALKTHROUGH_CLASS = 'text-base font-normal text-text font-[Quicksand] text-left leading-tight';
 
 // True iff `event` is the gate this step is waiting on.
 export function gateMatches(step: Step, event: GateEvent): boolean {
@@ -48,6 +53,7 @@ let stepIndex = 0;
 let waitingGate: GateEvent | null = null;
 let typing = false;
 let pendingGateHit = false;
+let brandOriginalClass: string | null = null; // captured before the first style swap
 const timers: ReturnType<typeof setTimeout>[] = [];
 
 function later(fn: () => void, ms: number): void {
@@ -148,6 +154,7 @@ function finish(): void {
     el.style.transition = '';
     el.style.opacity = '1';
     el.removeAttribute('aria-hidden');
+    if (brandOriginalClass !== null) el.className = brandOriginalClass; // restore wordmark size/font
   }
   setBrand('Clumeral');
 }
@@ -202,10 +209,22 @@ function start(): void {
   waitingGate = null;
   typing = false;
   pendingGateHit = false;
-  // Hide the typed prose from the a11y tree — the [data-walkthrough-live] region
-  // is the spoken channel. Prevents a Label-in-Name mismatch on the brand button
-  // (its aria-label stays "Home" while the visible text becomes tutorial prose).
-  brandTextEl()?.setAttribute('aria-hidden', 'true');
+  // Hold on the normal logo for ~5s, then the octopus starts talking.
+  later(begin, START_DELAY_MS);
+}
+
+// Fade the wordmark out and start the script. Runs after the start delay.
+function begin(): void {
+  if (!active) return;
+  const el = brandTextEl();
+  if (el) {
+    if (brandOriginalClass === null) brandOriginalClass = el.className;
+    el.className = WALKTHROUGH_CLASS;
+    // Hide the typed prose from the a11y tree — the [data-walkthrough-live] region
+    // is the spoken channel. Prevents a Label-in-Name mismatch on the brand button
+    // (its aria-label stays "Home" while the visible text becomes tutorial prose).
+    el.setAttribute('aria-hidden', 'true');
+  }
   fadeOutWordmark(() => runStep(0));
 }
 

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -16,12 +16,13 @@ export interface Step {
 
 export const STEPS: Step[] = [
   { kind: 'timed', text: "Looks like it's your first time here…" },
-  { kind: 'timed', text: 'The goal: work out the 3-digit number.' },
-  { kind: 'gated', text: 'Tap a big number box to open it…', gate: 'game:box-opened' },
-  { kind: 'timed', text: 'Remove numbers based on the clues…' },
+  { kind: 'timed', text: 'Goal: work out the number from 100–999…' },
+  { kind: 'gated', text: 'Tap a number box to begin…', gate: 'game:box-opened' },
   { kind: 'timed', text: "Example: clue says 'is a prime number'…" },
-  { kind: 'gated', text: 'Remove 0, 1, 4, 6, 8, and 9 (not prime)…', gate: 'game:digit-eliminated' },
-  { kind: 'timed', text: "When you're left with three, submit 💪" },
+  { kind: 'timed', text: 'Remove 0, 1, 4, 6, 8, 9 (not primes)…' },
+  { kind: 'gated', text: 'Tap a number to remove it…', gate: 'game:digit-eliminated' },
+  { kind: 'timed', text: 'Go until you have three left…' },
+  { kind: 'timed', text: 'Then submit your answer 💪' },
   { kind: 'end', text: '' },
 ];
 
@@ -75,6 +76,27 @@ function clearTimers(): void {
 
 function brandTextEl(): HTMLElement | null {
   return document.querySelector('[data-brand-text]');
+}
+
+function headerEl(): HTMLElement | null {
+  return document.querySelector('[data-app-header]');
+}
+
+// Pin the header while the octopus is talking so its message stays visible when
+// the player scrolls down to a digit box. Sticky keeps it in normal flow (no
+// content jump, unlike fixed). `pin(false)` restores the original static header.
+function pinHeader(on: boolean): void {
+  const el = headerEl();
+  if (!el) return;
+  if (on) {
+    el.style.position = 'sticky';
+    el.style.top = '0';
+    el.style.zIndex = '30';
+  } else {
+    el.style.position = '';
+    el.style.top = '';
+    el.style.zIndex = '';
+  }
 }
 
 function liveEl(): HTMLElement | null {
@@ -157,6 +179,7 @@ function finish(): void {
   typing = false;
   pendingGateHit = false;
   clearTimers();
+  pinHeader(false); // restore the static header
   const el = brandTextEl();
   if (el) {
     el.style.transition = '';
@@ -225,6 +248,7 @@ function start(): void {
 // Fade the wordmark out and start the script. Runs after the start delay.
 function begin(): void {
   if (!active) return;
+  pinHeader(true); // keep the header (and its message) visible while talking
   const el = brandTextEl();
   if (el) {
     if (brandOriginalClass === null) brandOriginalClass = el.className;

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -15,6 +15,8 @@ export interface Step {
 }
 
 export const STEPS: Step[] = [
+  { kind: 'timed', text: "Looks like it's your first time here…" },
+  { kind: 'timed', text: 'The goal: work out the 3-digit number.' },
   { kind: 'gated', text: 'Tap a big number box to open it…', gate: 'game:box-opened' },
   { kind: 'timed', text: 'Remove numbers based on the clues…' },
   { kind: 'timed', text: "Example: clue says 'is a prime number'…" },

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -15,15 +15,21 @@ export interface Step {
 }
 
 export const STEPS: Step[] = [
-  { kind: 'timed', text: "Looks like it's your first time here…" },
-  { kind: 'timed', text: 'The goal: work out the 3-digit number.' },
-  { kind: 'gated', text: 'Tap one of those big digit boxes to open it…', gate: 'game:box-opened' },
-  { kind: 'gated', text: "Now deselect digits it can't be using the clues", gate: 'game:digit-eliminated' },
+  { kind: 'gated', text: 'Tap a big number box to open it…', gate: 'game:box-opened' },
+  { kind: 'timed', text: 'Remove numbers based on the clues…' },
+  { kind: 'timed', text: "Example: clue says 'is a prime number'…" },
+  { kind: 'gated', text: 'Remove 0, 1, 4, 6, 8, and 9 (not prime)…', gate: 'game:digit-eliminated' },
+  { kind: 'timed', text: "When you're left with three, submit 💪" },
   { kind: 'end', text: '' },
 ];
 
 export const TYPE_MS = 45;
 export const DELETE_MS = 25;
+// Reading-gap scaling. With motion on, the type animation already paces reading,
+// so shorten the hold. With reduced motion the text appears instantly, so lengthen
+// it — otherwise it flashes by before it can be read.
+export const HOLD_FACTOR_MOTION = 0.75;
+export const HOLD_FACTOR_REDUCED = 1.25;
 // Hold on the normal logo for a beat before the octopus starts talking.
 export const START_DELAY_MS = 5000;
 // While talking, the brand text drops to clue size (16px), left-aligned, in the
@@ -178,7 +184,8 @@ function runStep(index: number): void {
   typeIn(step.text, () => {
     typing = false;
     if (step.kind === 'timed') {
-      later(() => deleteOut(() => runStep(index + 1)), holdMsFor(step.text));
+      const factor = REDUCED_MOTION() ? HOLD_FACTOR_REDUCED : HOLD_FACTOR_MOTION;
+      later(() => deleteOut(() => runStep(index + 1)), Math.round(holdMsFor(step.text) * factor));
     } else if (pendingGateHit) {
       // The user triggered the gate while the prompt was still typing — advance now.
       pendingGateHit = false;

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -38,8 +38,8 @@ export const HOLD_FACTOR_REDUCED = 1.25;
 // Hold on the normal logo for a beat before the octopus starts talking.
 export const START_DELAY_MS = 5000;
 // While talking, the brand text drops to clue size (16px), left-aligned, in the
-// clue font (Quicksand) — not the bold Comfortaa wordmark size.
-const WALKTHROUGH_CLASS = 'text-base font-normal text-text font-[Quicksand] text-left leading-tight';
+// clue font (Quicksand), in the theme accent colour — not the bold Comfortaa wordmark.
+const WALKTHROUGH_CLASS = 'text-base font-normal text-accent font-[Quicksand] text-left leading-tight';
 
 // True iff `event` is the gate this step is waiting on.
 export function gateMatches(step: Step, event: GateEvent): boolean {

--- a/tests/walkthrough.spec.ts
+++ b/tests/walkthrough.spec.ts
@@ -20,6 +20,14 @@ describe('walkthrough step machine', () => {
     expect(STEPS[5].gate).toBe('game:digit-eliminated');
   });
 
+  it('bold prefixes are real leading substrings of their step text', () => {
+    expect(STEPS[2].boldPrefix).toBe('Tap a number box');
+    expect(STEPS[5].boldPrefix).toBe('Tap a number');
+    for (const step of STEPS) {
+      if (step.boldPrefix) expect(step.text.startsWith(step.boldPrefix)).toBe(true);
+    }
+  });
+
   it('gateMatches advances only on the step’s own event', () => {
     expect(gateMatches(STEPS[2], 'game:box-opened')).toBe(true);
     expect(gateMatches(STEPS[2], 'game:digit-eliminated')).toBe(false);

--- a/tests/walkthrough.spec.ts
+++ b/tests/walkthrough.spec.ts
@@ -2,30 +2,31 @@ import { describe, it, expect } from 'vitest';
 import { STEPS, gateMatches, holdMsFor, TYPE_MS, DELETE_MS } from '../src/walkthrough.ts';
 
 describe('walkthrough step machine', () => {
-  it('has the 4-step flow plus an end step', () => {
-    expect(STEPS).toHaveLength(5);
-    expect(STEPS[0].kind).toBe('timed');
+  it('has the scripted flow ending in an end step', () => {
+    expect(STEPS).toHaveLength(6);
+    expect(STEPS[0].kind).toBe('gated');
     expect(STEPS[1].kind).toBe('timed');
-    expect(STEPS[2].kind).toBe('gated');
+    expect(STEPS[2].kind).toBe('timed');
     expect(STEPS[3].kind).toBe('gated');
-    expect(STEPS[4].kind).toBe('end');
+    expect(STEPS[4].kind).toBe('timed');
+    expect(STEPS[5].kind).toBe('end');
   });
 
   it('gated steps carry the matching game event', () => {
-    expect(STEPS[2].gate).toBe('game:box-opened');
+    expect(STEPS[0].gate).toBe('game:box-opened');
     expect(STEPS[3].gate).toBe('game:digit-eliminated');
   });
 
   it('gateMatches advances only on the step’s own event', () => {
-    expect(gateMatches(STEPS[2], 'game:box-opened')).toBe(true);
-    expect(gateMatches(STEPS[2], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(true);
+    expect(gateMatches(STEPS[0], 'game:digit-eliminated')).toBe(false);
     expect(gateMatches(STEPS[3], 'game:digit-eliminated')).toBe(true);
     expect(gateMatches(STEPS[3], 'game:box-opened')).toBe(false);
   });
 
   it('gateMatches is false for non-gated steps', () => {
-    expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(false);
-    expect(gateMatches(STEPS[4], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[1], 'game:box-opened')).toBe(false);
+    expect(gateMatches(STEPS[5], 'game:digit-eliminated')).toBe(false);
   });
 
   it('holdMsFor: 200 wpm + 1s buffer, 2s floor', () => {

--- a/tests/walkthrough.spec.ts
+++ b/tests/walkthrough.spec.ts
@@ -2,31 +2,33 @@ import { describe, it, expect } from 'vitest';
 import { STEPS, gateMatches, holdMsFor, TYPE_MS, DELETE_MS } from '../src/walkthrough.ts';
 
 describe('walkthrough step machine', () => {
-  it('has the scripted flow ending in an end step', () => {
-    expect(STEPS).toHaveLength(6);
-    expect(STEPS[0].kind).toBe('gated');
+  it('opens with the two timed intro lines and ends in an end step', () => {
+    expect(STEPS).toHaveLength(8);
+    expect(STEPS[0].kind).toBe('timed');
     expect(STEPS[1].kind).toBe('timed');
-    expect(STEPS[2].kind).toBe('timed');
-    expect(STEPS[3].kind).toBe('gated');
+    expect(STEPS[2].kind).toBe('gated');
+    expect(STEPS[3].kind).toBe('timed');
     expect(STEPS[4].kind).toBe('timed');
-    expect(STEPS[5].kind).toBe('end');
+    expect(STEPS[5].kind).toBe('gated');
+    expect(STEPS[6].kind).toBe('timed');
+    expect(STEPS[7].kind).toBe('end');
   });
 
   it('gated steps carry the matching game event', () => {
-    expect(STEPS[0].gate).toBe('game:box-opened');
-    expect(STEPS[3].gate).toBe('game:digit-eliminated');
+    expect(STEPS[2].gate).toBe('game:box-opened');
+    expect(STEPS[5].gate).toBe('game:digit-eliminated');
   });
 
   it('gateMatches advances only on the step’s own event', () => {
-    expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(true);
-    expect(gateMatches(STEPS[0], 'game:digit-eliminated')).toBe(false);
-    expect(gateMatches(STEPS[3], 'game:digit-eliminated')).toBe(true);
-    expect(gateMatches(STEPS[3], 'game:box-opened')).toBe(false);
+    expect(gateMatches(STEPS[2], 'game:box-opened')).toBe(true);
+    expect(gateMatches(STEPS[2], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[5], 'game:digit-eliminated')).toBe(true);
+    expect(gateMatches(STEPS[5], 'game:box-opened')).toBe(false);
   });
 
   it('gateMatches is false for non-gated steps', () => {
-    expect(gateMatches(STEPS[1], 'game:box-opened')).toBe(false);
-    expect(gateMatches(STEPS[5], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(false);
+    expect(gateMatches(STEPS[7], 'game:digit-eliminated')).toBe(false);
   });
 
   it('holdMsFor: 200 wpm + 1s buffer, 2s floor', () => {

--- a/tests/walkthrough.spec.ts
+++ b/tests/walkthrough.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { STEPS, gateMatches, holdMsFor, TYPE_MS, DELETE_MS } from '../src/walkthrough.ts';
+
+describe('walkthrough step machine', () => {
+  it('has the 4-step flow plus an end step', () => {
+    expect(STEPS).toHaveLength(5);
+    expect(STEPS[0].kind).toBe('timed');
+    expect(STEPS[1].kind).toBe('timed');
+    expect(STEPS[2].kind).toBe('gated');
+    expect(STEPS[3].kind).toBe('gated');
+    expect(STEPS[4].kind).toBe('end');
+  });
+
+  it('gated steps carry the matching game event', () => {
+    expect(STEPS[2].gate).toBe('game:box-opened');
+    expect(STEPS[3].gate).toBe('game:digit-eliminated');
+  });
+
+  it('gateMatches advances only on the step’s own event', () => {
+    expect(gateMatches(STEPS[2], 'game:box-opened')).toBe(true);
+    expect(gateMatches(STEPS[2], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[3], 'game:digit-eliminated')).toBe(true);
+    expect(gateMatches(STEPS[3], 'game:box-opened')).toBe(false);
+  });
+
+  it('gateMatches is false for non-gated steps', () => {
+    expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(false);
+    expect(gateMatches(STEPS[4], 'game:digit-eliminated')).toBe(false);
+  });
+
+  it('holdMsFor: 200 wpm + 1s buffer, 2s floor', () => {
+    expect(holdMsFor('one two three four five six seven')).toBe(
+      Math.max(Math.round((7 / 200) * 60_000) + 1000, 2000),
+    );
+    expect(holdMsFor('hi')).toBe(2000); // floor
+    expect(holdMsFor('   ')).toBe(2000); // no words → floor
+  });
+
+  it('type is slower than delete', () => {
+    expect(TYPE_MS).toBe(45);
+    expect(DELETE_MS).toBe(25);
+    expect(DELETE_MS).toBeLessThan(TYPE_MS);
+  });
+});

--- a/tests/walkthrough.spec.ts
+++ b/tests/walkthrough.spec.ts
@@ -3,7 +3,7 @@ import { STEPS, gateMatches, holdMsFor, TYPE_MS, DELETE_MS } from '../src/walkth
 
 describe('walkthrough step machine', () => {
   it('opens with the two timed intro lines and ends in an end step', () => {
-    expect(STEPS).toHaveLength(8);
+    expect(STEPS).toHaveLength(9);
     expect(STEPS[0].kind).toBe('timed');
     expect(STEPS[1].kind).toBe('timed');
     expect(STEPS[2].kind).toBe('gated');
@@ -11,7 +11,8 @@ describe('walkthrough step machine', () => {
     expect(STEPS[4].kind).toBe('timed');
     expect(STEPS[5].kind).toBe('gated');
     expect(STEPS[6].kind).toBe('timed');
-    expect(STEPS[7].kind).toBe('end');
+    expect(STEPS[7].kind).toBe('timed');
+    expect(STEPS[8].kind).toBe('end');
   });
 
   it('gated steps carry the matching game event', () => {
@@ -28,7 +29,7 @@ describe('walkthrough step machine', () => {
 
   it('gateMatches is false for non-gated steps', () => {
     expect(gateMatches(STEPS[0], 'game:box-opened')).toBe(false);
-    expect(gateMatches(STEPS[7], 'game:digit-eliminated')).toBe(false);
+    expect(gateMatches(STEPS[8], 'game:digit-eliminated')).toBe(false);
   });
 
   it('holdMsFor: 200 wpm + 1s buffer, 2s floor', () => {


### PR DESCRIPTION
## What

On a player's first game, the octopus mascot "talks" through the `/play` header — typing a scripted tutorial in place of the **Clumeral** wordmark — to teach the core mechanic in context. Frontend-only; no worker/API changes.

Closes #214.

## How

- New `src/walkthrough.ts` — a standalone module (imported for side-effect init from `app.ts`, like `octo.ts`). Owns the step-machine, the header typewriter, and event wiring.
- `app.ts` adds two one-line `CustomEvent` dispatches: `game:box-opened` (in `openBox`) and `game:digit-eliminated` (in `toggleDigit`, elimination branch only). No game logic touched.
- `index.html` gets `data-brand-text` on the wordmark span and a visually-hidden `data-walkthrough-live` `aria-live="polite"` region.

## Script (8 steps + restore)

| # | Type | Message |
|---|------|---------|
| 0 | timed | "Looks like it's your first time here…" |
| 1 | timed | "Work out the number from 100–999…" |
| 2 | gated → box opened | **"Tap a number box"** to begin… |
| 3 | timed | "Example: clue says 'is a prime number'…" |
| 4 | timed | "Remove 0, 1, 4, 6, 8, 9 (not primes)…" |
| 5 | gated → digit removed | **"Tap a number"** to remove it… |
| 6 | timed | "Go until each box has one number…" |
| 7 | timed | "Then submit your answer 💪" |

Timed steps auto-advance after a reading hold; gated steps wait on the matching game event (a fast tap mid-type is not lost). Then the wordmark restores to "Clumeral".

## Presentation

- **Start delay** — holds the normal logo ~5s before the octopus starts talking.
- **Typewriter** — type 45ms/char, delete 25ms/char; logo fades out first (no untype).
- **Hold timing is motion-aware** — ×0.75 with motion (typing already paces reading), ×1.25 with `prefers-reduced-motion` (instant text needs longer to read).
- **Type style** — 16px Quicksand (clue size), left-aligned, **bold**, in the **theme accent colour** (`--color-accent`, swaps per palette + light/dark). The action lead is **bold + _italic_** to stand apart.
- **Header pinned** — `position: sticky` while talking so the message stays visible when scrolling to a digit box; reverts to static on finish (chose sticky over fixed → no content jump).
- **`prefers-reduced-motion`** — text set instantly (no per-char animation), still advances.

## Accessibility

- `aria-live="polite"` announces the full sentence once per step — never letter-by-letter.
- Typed prose is `aria-hidden` while talking so the brand button keeps its "Home" accessible name (avoids a WCAG 2.5.3 Label-in-Name mismatch); the live region is the single spoken channel.

## Trigger / persistence

Runs on `screens:enter` for `game` when `dlng_history` is absent (read **live**, not snapshotted). The first solve writes `dlng_history` via the existing `recordGame()`, so it never shows again — **no new localStorage key**. A `hasRun` latch stops in-session re-triggers (game→welcome→game).

## ⚠️ AC divergence from the issue

v1 has **no skip control**. Suppression is by first solve (not "skipping persists"). Please update the issue's AC checklist accordingly when closing. (Skip / idle-nudge / replay-from-menu are deferred past v1 — see the spec.)

## Tests

- Unit (`tests/walkthrough.spec.ts`) — step-machine kinds/gates, bold-prefix integrity, timing helpers.
- E2E against the **production build** (`vite preview`) — first-visit typing, aria-live, both gated steps hold-then-advance, bold `<strong>` lead, header sticky-then-revert, wordmark restore, returning-player no-show, reduced-motion.
- Full suite green: 104 unit tests, 8 e2e (incl. existing octo-celebration).

## Review

DA review (fresh-context subagent) → self-review done on the core. DA found and fixed two mediums: stale `isNewUser` snapshot causing post-solve replay (M1), and a brand-button Label-in-Name / a11y-tree mismatch (M2). Later additions are copy/CSS plus a typewriter that emits a `<strong>` for the bold lead — text is hardcoded, so `innerHTML` there is not an injection surface.

## Merge target

**`new-design`** — NOT `staging`/`main`. Do not merge automatically; the user merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)