### PR TITLE
fix: midnight date divergence (UTC vs local) + stale archive brand

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-05-02)
 Phase: 07 (archive-replay-keep-header-date-archive-button-visible-so-us) — COMPLETE
 Plan: 1 of 1
 Status: Phase 7 complete + pushed to new-design — phase-level PR deferred (ships with v1.1 milestone PR to main)
-Last activity: 2026-05-31 - Completed quick task 260531-vwi: remove brand nav, bounce octopus logo on tap
+Last activity: 2026-06-01 - Completed quick task 260601-auy: fix midnight date divergence + stale archive brand
 
 Progress: [██████████] 100%
 
@@ -104,6 +104,7 @@ None.
 | 260531-nua | Remove range + "Clues:" copy from play screen | 2026-05-31 | 7abc418 | [260531-nua-remove-range-clues-copy-from-play-screen](./quick/260531-nua-remove-range-clues-copy-from-play-screen/) |
 | 260531-qjn | Docs cleanup (#215): thin CLAUDE.md to rules + pointers, refresh stale README structure | 2026-05-31 | 7434e9a | [260531-qjn-docs-cleanup-thin-claude-md-to-rules-poi](./quick/260531-qjn-docs-cleanup-thin-claude-md-to-rules-poi/) |
 | 260531-vwi | Remove nav from brand; tapping octopus logo / "Clumeral" wordmark bounces the logo | 2026-05-31 | 2302079 | [260531-vwi-remove-nav-from-brand-bounce-octopus-log](./quick/260531-vwi-remove-nav-from-brand-bounce-octopus-log/) |
+| 260601-auy | Fix midnight date divergence (UTC vs local) + stale archive brand link | 2026-06-01 | 60b8c9f | [260601-auy-midnight-date-divergence](./quick/260601-auy-midnight-date-divergence/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260601-auy-midnight-date-divergence/260601-auy-PLAN.md
+++ b/.planning/quick/260601-auy-midnight-date-divergence/260601-auy-PLAN.md
@@ -1,0 +1,106 @@
+---
+quick_id: 260601-auy
+slug: midnight-date-divergence
+date: 2026-06-01
+status: in-progress
+branch: fix/midnight-date-divergence
+---
+
+# Quick Task 260601-auy: Fix midnight date divergence + stale archive brand
+
+## Problem
+
+Two independent root causes from a friend's bug report on `new-design`:
+
+**Root cause A (bugs 1, 2, 3 — the midnight ones).** The worker keys the daily
+puzzle on UTC (`handleGetPuzzle` → `todayUTC`) while the client keys completion
+and streak on LOCAL date (`todayKey`). For a UK user in BST (UTC+1), between
+00:00 and 01:00 local the two disagree: the worker still serves yesterday's UTC
+puzzle, the solve is recorded under the worker date (`recordGame`), but
+`todayEntry()` looks it up under the LOCAL date and finds nothing. Symptoms:
+already-solved puzzle shows as not-completed; the Stats link (`/solved`) bounces
+to the how-to/welcome screen; a midnight-window solve gets mis-dated, punching a
+calendar-day hole that resets the streak.
+
+**Root cause B (bug 4 — the logo).** The SPA brand is a no-nav bounce button
+(`<button data-brand>`), but the worker-rendered `/archive` page still ships the
+old brand markup `<a href="/" class="brand">` → full nav to `/` → resolves to
+the welcome (how-to) screen.
+
+Repro proofs: `e2e/midnight-rollover-repro.spec.ts` (3 tests asserting the BUGGY
+behavior). These get rewritten into regression tests asserting the FIXED
+behavior.
+
+## Approach
+
+Make the LOCAL date canonical end-to-end. The client tells the worker which
+puzzle day it wants; the worker serves it, guarded by the existing +1-day
+tolerance in `isFuturePuzzleDate` (designed for exactly this — ahead-of-UTC
+local-midnight players, #205). Then puzzle, `recordGame`, `todayEntry`, and
+streak all key on the same date.
+
+## Tasks
+
+### Task 1 — Worker: `/api/puzzle` honours a client `?date=` param
+- **files:** `src/worker/index.ts`
+- **action:**
+  - Change `handleGetPuzzle(env)` → `handleGetPuzzle(env, url)`. Read
+    `url.searchParams.get('date')`. If it is a well-formed `YYYY-MM-DD` AND
+    `isFuturePuzzleDate(date)` is `false`, serve that date. Otherwise fall back
+    to `todayUTC()` (back-compat for clients that send no param, and fail-safe
+    for malformed/future values — the guard already rejects today+2 and garbage).
+  - Update the call site `handleGetPuzzle(env)` → `handleGetPuzzle(env, url)`.
+  - `isFuturePuzzleDate` is already imported. No new imports.
+- **verify:** `npx tsc --noEmit`; manual: `GET /api/puzzle?date=<yesterday>`
+  returns `{date:"<yesterday>", ...}`; `?date=<today+2>` and `?date=garbage`
+  fall back to UTC today; no param → UTC today.
+- **done:** worker serves the requested in-range date, falls back safely.
+
+### Task 2 — Client: send local date to `/api/puzzle`
+- **files:** `src/app.ts`
+- **action:** In `loadPuzzle()`, change the daily endpoint from `'/api/puzzle'`
+  to `` `/api/puzzle?date=${encodeURIComponent(todayKey())}` ``. `todayKey` is
+  already imported. Random path unchanged. Now `data.date === todayKey()`, so
+  `gameState.date`, `recordGame`, and `todayEntry` all align on the local day.
+- **verify:** `npx tsc --noEmit`; e2e asserts the outgoing request carries
+  `?date=<todayKey>` and `gameState.date === todayKey()`.
+- **done:** the daily fetch is keyed on the browser-local date.
+
+### Task 3 — Archive SSR brand: bounce, no nav (bug 4)
+- **files:** `src/worker/puzzles.ts`
+- **action:**
+  - Replace `<a href="/" class="brand" aria-label="Clumeral home">…</a>` with
+    `<button type="button" class="brand" aria-label="Bounce Clumeral">…</button>`
+    (same inner octo SVG + wordmark).
+  - Add a button reset to the `.brand` CSS rule (`background:none; border:0;
+    cursor:pointer; font:inherit; color:inherit;`) so the button looks identical.
+  - Add a small CSS keyframe bounce (transform translateY) on the octo SVG and a
+    tiny inline-script click handler on `.brand` that toggles the bounce class
+    (re-armable on `animationend`). No navigation — matches the SPA brand.
+- **verify:** e2e: clicking `.brand` on `/archive` keeps `location.pathname ===
+  '/archive'` (no nav to welcome/how-to); the octo plays a bounce.
+- **done:** the archive logo bounces in place like every other screen.
+
+### Task 4 — Rewrite repro spec into a regression spec
+- **files:** `e2e/midnight-rollover-repro.spec.ts` → rename to
+  `e2e/midnight-rollover.spec.ts`, invert assertions to the FIXED behavior:
+  - BUG 1 → a solve recorded under LOCAL today, clock in the BST window:
+    `/solved` shows the completion (stats) screen, NOT welcome.
+  - BUG 2 → `/play` requests `/api/puzzle?date=<todayKey>` and `data.date`
+    (hence `gameState.date`) equals `todayKey()`, so a solved puzzle is
+    recognised as completed.
+  - BUG 4 → clicking `.brand` on `/archive` does not navigate.
+- **verify:** `npx playwright test midnight-rollover` green.
+- **done:** the former repro now guards against regression.
+
+## Out of scope / leave as-is
+- Archive "Show stats" → `/solved` link: correct once root cause A holds (stats
+  live on `/solved`, which requires today's solve — by design).
+- `puzzleNumber`/`puzzleDate` epoch math and `/api/puzzle/:num`: unchanged — the
+  number↔date mapping is a fixed global mapping, not a "today" computation.
+- Cold-load rollover redirect (router.ts): already all-local, not part of root cause A.
+
+## QA / gates (per CLAUDE.md)
+- `npm test` (vitest) + `npx playwright test` (full e2e against production build).
+- DA review (fresh-context subagent) → self-review before PR.
+- Branch `fix/midnight-date-divergence` off `new-design`. PR, do NOT merge.

--- a/.planning/quick/260601-auy-midnight-date-divergence/260601-auy-SUMMARY.md
+++ b/.planning/quick/260601-auy-midnight-date-divergence/260601-auy-SUMMARY.md
@@ -1,0 +1,70 @@
+---
+quick_id: 260601-auy
+slug: midnight-date-divergence
+date: 2026-06-01
+status: complete
+branch: fix/midnight-date-divergence
+---
+
+# Quick Task 260601-auy — Summary
+
+Fixed two bugs reported by a friend testing `new-design` on Cloudflare.
+
+## Root causes
+
+**A — client LOCAL vs worker UTC date divergence (bugs 1-3).** The worker keyed
+the daily puzzle on UTC (`handleGetPuzzle`/`todayUTC`); the client keys
+completion and streak on LOCAL date (`date.ts` `todayKey`). For a UK BST (UTC+1)
+player between 00:00–01:00 local, the worker still served yesterday's UTC puzzle
+while the solve was recorded under that worker date — but `todayEntry()` looked
+it up under the LOCAL date and found nothing. Symptoms: already-solved puzzle
+shown as not-completed; Stats link (`/solved`) bouncing to the welcome/how-to
+screen; a midnight-window solve mis-dated, holing the run and resetting the
+streak (the "5"). The archive-testing theory was a red herring — incomplete
+games never call `recordGame`.
+
+**B — stale SSR archive brand (bug 4).** Quick task 260531-vwi made the SPA brand
+a no-nav bounce button but missed the worker-rendered `/archive` page, which
+still shipped `<a href="/" class="brand">` → full nav to `/` → resolved to the
+welcome (how-to) screen.
+
+## Fix
+
+Made the LOCAL date canonical end-to-end:
+- `src/app.ts` — `loadPuzzle()` sends `?date=${todayKey()}` to `/api/puzzle`.
+- `src/worker/index.ts` — `handleGetPuzzle(env, url)` honours an in-range
+  `?date=` (guarded by `isFuturePuzzleDate`, which allows today+1 for
+  ahead-of-UTC players, #205) and falls back to `todayUTC()` for
+  missing/future/malformed values. Response now sends `Cache-Control: no-store`.
+- `src/worker/puzzles.ts` — archive brand is now a no-nav `<button>` with a
+  reduced-motion-aware CSS bounce + a `:focus-visible` ring.
+
+Now the served puzzle, `recordGame`, `todayEntry`, and streak all key on the
+same local day.
+
+## Commits
+- `fix(260601-auy): /api/puzzle honours client local ?date= (in-range)`
+- `fix(260601-auy): client sends local date to /api/puzzle`
+- `fix(260601-auy): archive logo bounces in place, no nav to how-to`
+- `test(260601-auy): regression suite for midnight date divergence + archive brand`
+- `fix(260601-auy): address DA review — focus ring, no-store, mirror test`
+
+## QA / gates
+- Unit: `npm test` → 104/104.
+- E2E (production build): `npx playwright test` → 16/16, incl. the new
+  `e2e/midnight-rollover.spec.ts` (8 cases: worker in-range/future/malformed,
+  client local-date request, negative-offset mirror, solved recognition, stats
+  link, archive bounce).
+- DA review (fresh-context subagent): no Medium+ findings. Low items resolved:
+  focus ring, `no-store`, mirror test. Deferred (justified): brand-as-button
+  a11y semantics — kept for SPA parity.
+- Self-review: passed (comments match code, rename propagated, no schema/answer
+  leak, sw.js network-only for `/api/*` unchanged).
+
+## Deferred
+- `/api/puzzle` button-with-no-action a11y semantic — inherited SPA pattern; keep
+  for parity, revisit if the brand interaction is reconsidered.
+
+## Branch / merge
+Branch `fix/midnight-date-divergence` off `new-design`. PR opened; NOT merged
+(user merges on GitHub).

--- a/e2e/midnight-rollover.spec.ts
+++ b/e2e/midnight-rollover.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Regression suite — friend's bug report on new-design (quick task 260601-auy).
+//
+// ROOT CAUSE A (bugs 1-3): the worker keyed the daily puzzle on UTC while the
+// client keys completion + streak on LOCAL date. For a UK user in BST (UTC+1),
+// between 00:00 and 01:00 local the two diverged — yesterday's puzzle served,
+// the solve recorded under a date todayEntry() never looks up. Fix: the client
+// sends its local date to /api/puzzle and the worker serves that date (bounded
+// by the existing +1-day isFuturePuzzleDate tolerance), so puzzle, recordGame,
+// and todayEntry all key on the same local day.
+//
+// ROOT CAUSE B (bug 4): the worker-rendered /archive page shipped the old
+// <a href="/" class="brand"> markup — a full nav to / that resolves to the
+// welcome (how-to) screen. Fix: it's now a no-nav bounce button like the SPA.
+
+// 2026-05-31 23:30:00Z === 2026-06-01 00:30 BST (UTC+1): browser-local "today"
+// is 2026-06-01 while UTC "today" is still 2026-05-31 — the divergence window.
+const MIDNIGHT_WINDOW = new Date("2026-05-31T23:30:00Z");
+const LOCAL_TODAY = "2026-06-01";
+
+async function seedSolvedToday(page: Page) {
+  await page.clock.install({ time: MIDNIGHT_WINDOW });
+  await page.addInitScript((today) => {
+    // A finished solve recorded — as the fixed client does — under the LOCAL date.
+    localStorage.setItem(
+      "dlng_history",
+      JSON.stringify([{ date: today, tries: 2, answer: 123 }]),
+    );
+    localStorage.setItem("dlng_uid", "regr-uid");
+    localStorage.setItem("dlng_last_visit_date", today);
+  }, LOCAL_TODAY);
+}
+
+test.describe("worker: /api/puzzle honours an in-range client ?date=", () => {
+  test("serves the requested past date verbatim", async ({ request }) => {
+    // A past date is always in range — no coupling to the host's wall clock.
+    const res = await request.get("/api/puzzle?date=2026-03-10");
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.date).toBe("2026-03-10");
+    expect(Array.isArray(body.clues)).toBeTruthy();
+  });
+
+  test("falls back to UTC today for a future date (guard rejects today+2)", async ({ request }) => {
+    const res = await request.get("/api/puzzle?date=2030-01-01");
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.date).not.toBe("2030-01-01");
+    expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("falls back to UTC today for a malformed date", async ({ request }) => {
+    const res = await request.get("/api/puzzle?date=not-a-date");
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+test.describe("client keys the puzzle day on the browser-local date", () => {
+  test.use({ timezoneId: "Europe/London", locale: "en-GB" });
+
+  test("loadPuzzle requests /api/puzzle with the local date", async ({ page }) => {
+    await page.clock.install({ time: MIDNIGHT_WINDOW });
+    const req = page.waitForRequest((r) => r.url().includes("/api/puzzle?date="));
+    await page.goto("/play");
+    const url = new URL((await req).url());
+    expect(url.searchParams.get("date")).toBe(LOCAL_TODAY);
+  });
+
+  test("a puzzle solved under the local date is recognised — /play redirects to the solved view, not a fresh board", async ({ page }) => {
+    await seedSolvedToday(page);
+
+    await page.goto("/play");
+
+    // todayEntry() now matches the seeded solve (both keyed on local today), so
+    // the resolver treats today as solved and sends /play → /solved. Pre-fix it
+    // found nothing and rendered a fresh, playable board for an already-solved
+    // puzzle.
+    await expect(page.locator('[data-screen="completion"]')).not.toHaveAttribute("aria-hidden", "true");
+    await expect(page.locator('[data-screen="game"]')).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("the Stats link reaches the completion/stats screen, not the how-to screen", async ({ page }) => {
+    await seedSolvedToday(page);
+    await page.goto("/solved");
+
+    // todayEntry() now matches (solve keyed on local today), so /solved resolves
+    // to the completion screen — the stats are shown, not the welcome/how-to.
+    await expect(page.locator('[data-screen="completion"]')).not.toHaveAttribute("aria-hidden", "true");
+    await expect(page.locator('[data-screen="welcome"]')).toHaveAttribute("aria-hidden", "true");
+  });
+});
+
+test.describe("archive brand bounces in place", () => {
+  test("clicking 'Clumeral' on /archive does NOT navigate to the how-to screen", async ({ page }) => {
+    await page.goto("/archive");
+
+    const brand = page.locator("button.brand");
+    await expect(brand).toBeVisible(); // it's a button now, not a link
+    expect(await page.locator('a.brand[href="/"]').count()).toBe(0);
+
+    await brand.click();
+    // Give any (incorrect) navigation a chance to happen, then assert we stayed.
+    await page.waitForTimeout(300);
+    expect(new URL(page.url()).pathname).toBe("/archive");
+  });
+});

--- a/e2e/midnight-rollover.spec.ts
+++ b/e2e/midnight-rollover.spec.ts
@@ -69,6 +69,19 @@ test.describe("client keys the puzzle day on the browser-local date", () => {
     expect(url.searchParams.get("date")).toBe(LOCAL_TODAY);
   });
 
+  test("negative-offset late evening: still keys on the player's local date, not UTC tomorrow", async ({ browser }) => {
+    // Mirror of the BST bug. UTC-5 (New York) at 23:30 local: UTC has already
+    // rolled to the next day, so a UTC-keyed client would request tomorrow.
+    // 2026-06-01T03:30:00Z === 2026-05-31 23:30 EDT → local date is 2026-05-31.
+    const ctx = await browser.newContext({ timezoneId: "America/New_York", locale: "en-US" });
+    const page = await ctx.newPage();
+    await page.clock.install({ time: new Date("2026-06-01T03:30:00Z") });
+    const req = page.waitForRequest((r) => r.url().includes("/api/puzzle?date="));
+    await page.goto("/play");
+    expect(new URL((await req).url()).searchParams.get("date")).toBe("2026-05-31");
+    await ctx.close();
+  });
+
   test("a puzzle solved under the local date is recognised — /play redirects to the solved view, not a fresh board", async ({ page }) => {
     await seedSolvedToday(page);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -731,7 +731,12 @@ async function handleGuess() {
 
 async function loadPuzzle() {
   const isRandom = window.location.pathname === '/random';
-  const endpoint = isRandom ? '/api/puzzle/random' : '/api/puzzle';
+  // Send the browser-LOCAL date so the worker serves the puzzle for the player's
+  // local day, not UTC today. This keeps the served puzzle, recordGame, and
+  // todayEntry all keyed on the same date (todayKey) — without it, a UTC+offset
+  // player in the local/UTC-midnight window gets a mismatched day (the
+  // not-completed / stats-bounce / streak-reset bugs).
+  const endpoint = isRandom ? '/api/puzzle/random' : `/api/puzzle?date=${encodeURIComponent(todayKey())}`;
 
   try {
     const res = await fetch(endpoint);

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -53,11 +53,21 @@ async function getDailyPuzzle(env: Env, date: string): Promise<StoredPuzzle> {
 
 // ─── Route handlers ──────────────────────────────────────────────────────────
 
-async function handleGetPuzzle(env: Env): Promise<Response> {
-  const today = todayUTC();
-  const puzzle = await getDailyPuzzle(env, today);
+async function handleGetPuzzle(env: Env, url: URL): Promise<Response> {
+  // The client keys the puzzle day on its LOCAL date (date.ts todayKey) and
+  // sends it as ?date=. Honour it when it's a well-formed, in-range date so the
+  // served puzzle matches the client's local day — otherwise a UTC+offset player
+  // in the window between local and UTC midnight gets the wrong day's puzzle
+  // (the divergence behind the not-completed / stats-bounce / streak bugs).
+  // isFuturePuzzleDate already rejects today+2 and malformed input (the +1-day
+  // tolerance is exactly the ahead-of-UTC local-midnight case, #205), so any
+  // rejected value falls back to the worker's UTC today (also the no-param
+  // back-compat path).
+  const requested = url.searchParams.get('date');
+  const date = requested && !isFuturePuzzleDate(requested) ? requested : todayUTC();
+  const puzzle = await getDailyPuzzle(env, date);
   return json({
-    date: today,
+    date,
     puzzleNumber: puzzle.puzzleNumber,
     clues: puzzle.clues,
   });
@@ -118,7 +128,7 @@ export default {
     // ── API routes ──
 
     if (request.method === 'GET' && url.pathname === '/api/puzzle') {
-      return handleGetPuzzle(env);
+      return handleGetPuzzle(env, url);
     }
 
     if (request.method === 'GET' && url.pathname === '/api/puzzle/random') {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -29,10 +29,10 @@ const VALID_EVENTS = new Set([
   'route_change',
 ]);
 
-function json(data: unknown, status = 200): Response {
+function json(data: unknown, status = 200, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
 
@@ -66,11 +66,17 @@ async function handleGetPuzzle(env: Env, url: URL): Promise<Response> {
   const requested = url.searchParams.get('date');
   const date = requested && !isFuturePuzzleDate(requested) ? requested : todayUTC();
   const puzzle = await getDailyPuzzle(env, date);
-  return json({
-    date,
-    puzzleNumber: puzzle.puzzleNumber,
-    clues: puzzle.clues,
-  });
+  // no-store: the response now varies by ?date= and is day-sensitive — never let
+  // an intermediary pin one player's local-day (or today+1) response past rollover.
+  return json(
+    {
+      date,
+      puzzleNumber: puzzle.puzzleNumber,
+      clues: puzzle.clues,
+    },
+    200,
+    { 'Cache-Control': 'no-store' },
+  );
 }
 
 async function handleGetRandomPuzzle(env: Env): Promise<Response> {

--- a/src/worker/puzzles.ts
+++ b/src/worker/puzzles.ts
@@ -108,6 +108,10 @@ export function renderArchivePage(puzzles: PuzzleSummary[]): string {
     font: inherit;
     cursor: pointer;
   }
+  header.app-header .brand:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
   header.app-header .brand .brand-octo {
     transform-origin: center bottom;
   }

--- a/src/worker/puzzles.ts
+++ b/src/worker/puzzles.ts
@@ -100,6 +100,29 @@ export function renderArchivePage(puzzles: PuzzleSummary[]): string {
     align-items: center;
     gap: 0.5rem;
     color: var(--color-text);
+    /* Button reset — the brand is a no-nav bounce trigger, not a link, so it
+       matches the SPA header brand (tap bounces the octopus, never navigates). */
+    background: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+  }
+  header.app-header .brand .brand-octo {
+    transform-origin: center bottom;
+  }
+  header.app-header .brand.bounce .brand-octo {
+    animation: brand-bounce 0.5s ease;
+  }
+  @keyframes brand-bounce {
+    0%   { transform: translateY(0); }
+    30%  { transform: translateY(-12px); }
+    55%  { transform: translateY(0); }
+    75%  { transform: translateY(-4px); }
+    100% { transform: translateY(0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    header.app-header .brand.bounce .brand-octo { animation: none; }
   }
   header.app-header .wordmark {
     font-family: "Comfortaa", "Quicksand", system-ui, sans-serif;
@@ -222,15 +245,15 @@ export function renderArchivePage(puzzles: PuzzleSummary[]): string {
 </head>
 <body>
   <header class="app-header">
-    <a href="/" class="brand" aria-label="Clumeral home">
-      <svg aria-hidden="true" width="24" height="24" viewBox="0 0 53 52" fill="none">
+    <button type="button" class="brand" aria-label="Bounce Clumeral">
+      <svg class="brand-octo" aria-hidden="true" width="24" height="24" viewBox="0 0 53 52" fill="none">
         <path d="M53 48C53 50.2091 51.2091 52 49 52H48C45.7909 52 44 50.2091 44 48V41H42V48C42 50.2091 40.2091 52 38 52H37C34.7909 52 33 50.2091 33 48V41H31V48C31 50.2091 29.2091 52 27 52H26C23.7909 52 22 50.2091 22 48V41H20V48C20 50.2091 18.2091 52 16 52H15C12.7909 52 11 50.2091 11 48V41H9V48C9 50.2091 7.20914 52 5 52H4C1.79086 52 6.44266e-08 50.2091 0 48V15C1.9329e-07 6.71573 6.71573 0 15 0H38C46.2843 5.47619e-07 53 6.71573 53 15V48Z" fill="var(--color-accent)"/>
         <circle cx="19" cy="15" r="2.5" fill="#F6F0E8"/>
         <circle cx="33" cy="15" r="2.5" fill="#F6F0E8"/>
         <path d="M21 26C24.3333 27.3333 27.6667 27.3333 31 26" stroke="#F6F0E8" stroke-width="1.5" stroke-linecap="round"/>
       </svg>
       <span class="wordmark">Clumeral</span>
-    </a>
+    </button>
   </header>
 
   <main class="archive">
@@ -260,6 +283,21 @@ export function renderArchivePage(puzzles: PuzzleSummary[]): string {
   </footer>
 
 <script>
+// Header brand: bounce the octopus on tap, never navigate — mirrors the SPA
+// header brand (src/app.ts [data-brand] → bounceBrand). Re-armable each tap.
+(function() {
+  var brand = document.querySelector(".brand");
+  if (!brand) return;
+  brand.addEventListener("click", function() {
+    brand.classList.remove("bounce");
+    void brand.offsetWidth; // reflow so the animation can replay
+    brand.classList.add("bounce");
+  });
+  brand.addEventListener("animationend", function() {
+    brand.classList.remove("bounce");
+  });
+})();
+
 // Populate tries column from localStorage
 (function() {
   var history = [];


### PR DESCRIPTION
Fixes two bugs spotted while testing `new-design` on Cloudflare.

## Root causes

**A — client LOCAL vs worker UTC date divergence (bugs 1–3).** The worker keyed the daily puzzle on UTC (`handleGetPuzzle`/`todayUTC`); the client keys completion + streak on LOCAL date (`date.ts` `todayKey`). For a UK BST (UTC+1) player between 00:00–01:00 local, the worker still served yesterday's UTC puzzle, the solve recorded under that worker date, but `todayEntry()` looked it up under the LOCAL date and found nothing. Symptoms:
- already-solved puzzle shown as **not completed**;
- the **Stats link** (`/solved`) bouncing to the welcome/how-to screen;
- a midnight-window solve mis-dated → calendar-day hole → **streak reset** (the "5").

(The archive-testing theory was a red herring — incomplete games never call `recordGame`.)

**B — stale SSR archive brand (bug 4).** Quick task 260531-vwi made the SPA brand a no-nav bounce button but missed the worker-rendered `/archive` page, which still shipped `<a href="/" class="brand">` → full nav to `/` → resolved to the welcome (how-to) screen.

## Fix — make the LOCAL date canonical end-to-end

- `src/app.ts` — `loadPuzzle()` sends `?date=${todayKey()}` to `/api/puzzle`.
- `src/worker/index.ts` — `handleGetPuzzle(env, url)` honours an in-range `?date=` (guarded by `isFuturePuzzleDate`, which already allows today+1 for ahead-of-UTC players, #205) and falls back to `todayUTC()` for missing/future/malformed values. Response sends `Cache-Control: no-store`.
- `src/worker/puzzles.ts` — archive brand is now a no-nav `<button>` with a reduced-motion-aware CSS bounce + `:focus-visible` ring.

Now the served puzzle, `recordGame`, `todayEntry`, and streak all key on the same local day.

## QA / gates
- Unit: `npm test` → **104/104**.
- E2E (production build): `npx playwright test` → **16/16**, incl. new `e2e/midnight-rollover.spec.ts` (worker in-range/future/malformed, client local-date request, negative-offset mirror, solved recognition, stats link, archive bounce).
- DA review (fresh-context subagent): **no Medium+ findings**; Low items resolved (focus ring, no-store, mirror test). Self-review passed.

## Notes
- One streak caveat: existing localStorage histories already corrupted by the old mis-dating won't self-heal — this stops future corruption. Flag if you want a one-time migration.
- Do **not** merge — opening for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)