### PR TITLE
QA regression suite — Playwright, full browser matrix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,14 +16,11 @@ Rules that keep it from rotting:
 
 ## Now — WIP 1
 
-- QA regression suite — build per [the design spec](superpowers/specs/2026-05-31-playwright-qa-regression-design.md) _(no issue — the spec is the tracking artifact; `/play` walkthrough behaviour is now stable enough to assert against)_
-
-## Future / ideas — conditional
-
-- [#213](https://github.com/jevawin/clumeral-game/issues/213) Supabase feedback migration — `when:` QA suite is green (the one-line feedback-intercept swap is then covered by tests)
+- [#213](https://github.com/jevawin/clumeral-game/issues/213) Supabase feedback migration — now unblocked (QA suite green); the one-line feedback-intercept swap is covered by `e2e/specs/menu.spec.ts`. `when:` QA suite branch merges.
 
 ## Recently shipped
 
+- 2026-06-08 — QA regression suite — 38 Playwright specs, full 5-engine matrix green (branch `qa/playwright-regression-suite`, [design](superpowers/specs/2026-05-31-playwright-qa-regression-design.md))
 - 2026-06-07 — [#214](https://github.com/jevawin/clumeral-game/issues/214) First-play octopus walkthrough — header tutorial on `/play` (`src/walkthrough.ts`)
 - 2026-06-07 — DST date tests made timezone-deterministic (`451879e`)
 - 2026-06-07 — Streak under-counting fix — sort history before streak walk (`13d98da`, 260607-df0)

--- a/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
+++ b/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
@@ -1,7 +1,25 @@
 # Playwright QA Regression Suite — Design
 
 Date: 2026-05-31
-Status: Approved (design) → implementation pending
+Status: Implemented 2026-06-08 (branch `qa/playwright-regression-suite`)
+
+## Implementation notes (2026-06-08)
+
+Built per this design. 38 specs across `e2e/specs/`, green on the full 5-engine
+matrix (chromium/webkit/firefox desktop + mobile chromium/webkit): 175 passed,
+0 failed. Existing ad-hoc specs kept under a `legacy-chromium` project.
+
+Deviations from the design, all deliberate:
+- **a11y scope:** axe runs on Chromium desktop + mobile only (DOM/ARIA/contrast
+  are engine-independent); behavioral specs cover all 5 engines.
+- **Countdown:** asserted as a clock-derived static value — the countdown renders
+  once, it does not tick live (design assumed a live tick).
+- **Brand "home":** dropped — the brand is a no-nav bounce since 260601-auy, not a
+  home link.
+- **Deferred (fragile, lower value):** the /archive SSR-handoff analytics beacon
+  assertion and the visibility/focus stale-day rollover test. Tracked here for a
+  later pass.
+- **Console guard** allowlists external Google-Fonts/SW noise (offline hosts).
 
 ## Goal
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,30 @@
+import { test as base, expect } from "@playwright/test";
+import { attachConsoleGuard, type ConsoleGuard } from "./helpers/console.ts";
+
+// Custom `test` for the structured suite. Every test gets:
+//  - a console guard that fails the test on unexpected console.error / pageerror
+//    in built output (real regressions), and
+//  - the external feedback endpoint stubbed at the network boundary, so the real
+//    client send code runs but nothing leaves the machine.
+//
+// Import { test, expect } from "../fixtures.ts" in specs under e2e/specs/.
+export const test = base.extend<{ consoleGuard: ConsoleGuard }>({
+  consoleGuard: [
+    async ({ page }, use) => {
+      const guard = attachConsoleGuard(page);
+
+      // Feedback → Google Apps Script. Fulfil 200 so the client's success path runs;
+      // no real network call leaves. When #213 (Supabase feedback) lands, swap this
+      // for the same-origin POST /api/feedback and drop the Google pattern.
+      await page.route("**/script.google.com/**", (route) =>
+        route.fulfill({ status: 200, contentType: "application/json", body: "{}" }),
+      );
+
+      await use(guard);
+      guard.assertClean();
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/e2e/helpers/clock.ts
+++ b/e2e/helpers/clock.ts
@@ -1,0 +1,20 @@
+import type { Page } from "@playwright/test";
+
+// Time control via Playwright's page.clock. Must be installed BEFORE the first
+// navigation for rollover/countdown tests — the app reads "now" at boot.
+
+// Freeze "now" to a fixed instant. Accepts an ISO string or Date.
+export async function freezeDate(page: Page, iso: string | Date): Promise<void> {
+  await page.clock.install({ time: new Date(iso) });
+}
+
+// Advance the frozen clock by a number of milliseconds (ticks timers, countdowns).
+export async function advanceBy(page: Page, ms: number): Promise<void> {
+  await page.clock.runFor(ms);
+}
+
+// Jump forward to a later instant without running every intermediate timer —
+// useful for "next day" rollover where you don't want to fire a day of timers.
+export async function jumpTo(page: Page, iso: string | Date): Promise<void> {
+  await page.clock.setFixedTime(new Date(iso));
+}

--- a/e2e/helpers/console.ts
+++ b/e2e/helpers/console.ts
@@ -9,21 +9,17 @@ const ALLOW: RegExp[] = [
   // app swallows these by design and they are not user-facing errors.
   /script\.google\.com/i,
   /\/api\/event/i,
-  // Documented /stats fallback: the Worker returns 503 when analytics secrets are
-  // absent (the usual case on local preview). The browser logs the failed document
-  // load as a console error — expected, not a regression.
-  /Failed to load resource: the server responded with a status of 503/i,
   // External Google Fonts noise. When the test host can't reach fonts.gstatic.com
   // (offline CI / sandbox), the @font-face downloads fail and the SW can't return a
   // Response for the cross-origin fetch. Firefox surfaces all of this as console
   // errors; the app falls back to system fonts. Environmental, not a regression —
   // production reaches Google Fonts normally. (SW cross-origin handling is tracked
-  // separately as a minor follow-up.)
-  /fonts\.gstatic\.com|fonts\.googleapis\.com/i,
-  /downloadable font/i,
-  /Cross-Origin Request Blocked/i,
-  /ServiceWorker passed a promise to FetchEvent\.respondWith/i,
-  /not, or is no longer, usable/i,
+  // separately as a minor follow-up.) Patterns are scoped to the fonts host / SW
+  // wording so they can't mask a genuine same-origin error.
+  /fonts\.(gstatic|googleapis)\.com/i, // also matches the "Cross-Origin Request Blocked … fonts.gstatic.com" line
+  /downloadable font: download failed/i,
+  /ServiceWorker passed a promise to FetchEvent\.respondWith\(\) that resolved with non-Response/i,
+  /An attempt was made to use an object that is not, or is no longer, usable/i,
 ];
 
 export interface ConsoleGuard {

--- a/e2e/helpers/console.ts
+++ b/e2e/helpers/console.ts
@@ -13,6 +13,17 @@ const ALLOW: RegExp[] = [
   // absent (the usual case on local preview). The browser logs the failed document
   // load as a console error — expected, not a regression.
   /Failed to load resource: the server responded with a status of 503/i,
+  // External Google Fonts noise. When the test host can't reach fonts.gstatic.com
+  // (offline CI / sandbox), the @font-face downloads fail and the SW can't return a
+  // Response for the cross-origin fetch. Firefox surfaces all of this as console
+  // errors; the app falls back to system fonts. Environmental, not a regression —
+  // production reaches Google Fonts normally. (SW cross-origin handling is tracked
+  // separately as a minor follow-up.)
+  /fonts\.gstatic\.com|fonts\.googleapis\.com/i,
+  /downloadable font/i,
+  /Cross-Origin Request Blocked/i,
+  /ServiceWorker passed a promise to FetchEvent\.respondWith/i,
+  /not, or is no longer, usable/i,
 ];
 
 export interface ConsoleGuard {

--- a/e2e/helpers/console.ts
+++ b/e2e/helpers/console.ts
@@ -1,0 +1,52 @@
+import type { Page } from "@playwright/test";
+
+// Known-benign console noise. Keep this list tight — every entry is a deliberate
+// exception, not a catch-all. Add a pattern only when you've confirmed the message
+// is harmless (e.g. a third-party beacon failing against a stubbed endpoint).
+const ALLOW: RegExp[] = [
+  /favicon\.ico/i,
+  // Analytics/feedback beacons may fail against stubs or the local Worker — the
+  // app swallows these by design and they are not user-facing errors.
+  /script\.google\.com/i,
+  /\/api\/event/i,
+  // Documented /stats fallback: the Worker returns 503 when analytics secrets are
+  // absent (the usual case on local preview). The browser logs the failed document
+  // load as a console error — expected, not a regression.
+  /Failed to load resource: the server responded with a status of 503/i,
+];
+
+export interface ConsoleGuard {
+  /** Throw if any non-allowlisted console.error / pageerror was seen. */
+  assertClean(): void;
+  /** Raw collected messages, for debugging. */
+  readonly errors: readonly string[];
+}
+
+// Attach a guard that records console.error and uncaught pageerror events. Call
+// assertClean() at the end of a test (the fixture does this automatically) to fail
+// on any unexpected error — these are real regressions in built output.
+export function attachConsoleGuard(page: Page): ConsoleGuard {
+  const errors: string[] = [];
+  const allowed = (text: string) => ALLOW.some((re) => re.test(text));
+
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (!allowed(text)) errors.push(`console.error: ${text}`);
+  });
+  page.on("pageerror", (err) => {
+    const text = err.message ?? String(err);
+    if (!allowed(text)) errors.push(`pageerror: ${text}`);
+  });
+
+  return {
+    errors,
+    assertClean() {
+      if (errors.length) {
+        throw new Error(
+          `Console guard caught ${errors.length} unexpected error(s):\n  ${errors.join("\n  ")}`,
+        );
+      }
+    },
+  };
+}

--- a/e2e/helpers/game-setup.ts
+++ b/e2e/helpers/game-setup.ts
@@ -1,0 +1,17 @@
+import { expect, type Page } from "@playwright/test";
+import { seedHistory } from "./storage.ts";
+import { expectActiveScreen } from "./screens.ts";
+
+// Land on a playable game board at /play.
+//
+// RTE-03 redirects: a fresh visitor (no history) bounces to /welcome, and a player
+// who already solved today bounces to /solved. So we seed one PAST history entry —
+// hasData=true, todayEntry=null → /play renders the game. Past (not today) history
+// also keeps the first-play walkthrough off, so solve specs stay deterministic
+// (no 5s header animation racing the keypad).
+export async function gotoPlayableGame(page: Page): Promise<void> {
+  await seedHistory(page, [{ date: "2026-01-01", tries: 3, answer: 123 }]);
+  await page.goto("/play");
+  await expectActiveScreen(page, "game");
+  await expect(page.locator("[data-clue-list]")).toBeVisible();
+}

--- a/e2e/helpers/screens.ts
+++ b/e2e/helpers/screens.ts
@@ -1,0 +1,21 @@
+import { expect, type Page } from "@playwright/test";
+
+type ScreenName = "welcome" | "game" | "completion";
+
+// The three-screen state machine toggles aria-hidden on each <section data-screen>.
+// The active screen has aria-hidden absent/false; inactive screens are "true".
+export async function expectActiveScreen(page: Page, name: ScreenName): Promise<void> {
+  const others: ScreenName[] = (["welcome", "game", "completion"] as ScreenName[]).filter(
+    (s) => s !== name,
+  );
+  await expect(page.locator(`[data-screen="${name}"]`)).not.toHaveAttribute(
+    "aria-hidden",
+    "true",
+  );
+  for (const other of others) {
+    await expect(page.locator(`[data-screen="${other}"]`)).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  }
+}

--- a/e2e/helpers/screens.ts
+++ b/e2e/helpers/screens.ts
@@ -19,3 +19,14 @@ export async function expectActiveScreen(page: Page, name: ScreenName): Promise<
     );
   }
 }
+
+// Wait for a screen to finish its fade-in (opacity → 1). The screens cross-fade
+// over ~250ms; run this before injecting axe so analysis doesn't race the
+// transition (which under parallel load can destroy the eval context).
+export async function waitForScreenSettled(page: Page, name: ScreenName): Promise<void> {
+  const loc = page.locator(`[data-screen="${name}"]`);
+  await expect(loc).not.toHaveAttribute("aria-hidden", "true");
+  await expect
+    .poll(async () => loc.evaluate((el) => getComputedStyle(el).opacity), { timeout: 10_000 })
+    .toBe("1");
+}

--- a/e2e/helpers/solve.ts
+++ b/e2e/helpers/solve.ts
@@ -1,0 +1,60 @@
+import { expect, type Page } from "@playwright/test";
+
+// Read the real 3-digit answer from the local preview Worker. `/api/dev/answer`
+// 404s on clumeral.com, so this only works against the local build — if it ever
+// runs against prod it fails loudly, which is correct (the suite must not run there).
+//
+// Without a token it returns today's (UTC) daily answer; with an archive replay
+// token it returns that puzzle's answer.
+export async function readAnswer(page: Page, token?: string): Promise<number[]> {
+  const url = token
+    ? `/api/dev/answer?token=${encodeURIComponent(token)}`
+    : "/api/dev/answer";
+  const res = await page.request.get(url);
+  expect(res.ok(), "/api/dev/answer must be reachable on the local preview").toBeTruthy();
+  const { answer } = (await res.json()) as { answer: number };
+  return String(answer).padStart(3, "0").split("").map(Number);
+}
+
+// Reduce each digit box to a single target digit by eliminating the others through
+// the real keypad — the genuine box → eliminate → resolve flow, not a shortcut.
+//
+// Box 0 starts {1..9} (no leading zero; the 0 key is disabled). Boxes 1-2 start
+// {0..9}. We click every non-target candidate exactly once; we never click the
+// target, so the "cannot eliminate the last digit" guard never trips.
+export async function setBoxes(page: Page, digits: number[]): Promise<void> {
+  for (let box = 0; box < 3; box++) {
+    await page.locator(`[data-digit="${box}"]`).click();
+    await expect(page.locator("[data-keypad] [data-key]").first()).toBeVisible();
+    for (let d = 0; d <= 9; d++) {
+      if (d === digits[box]) continue;
+      if (box === 0 && d === 0) continue; // key disabled — no leading zero
+      await page.locator(`[data-key="${d}"]`).click();
+    }
+  }
+}
+
+// Solve the puzzle end-to-end and submit. Returns the answer digits for assertions.
+export async function solvePuzzle(
+  page: Page,
+  opts: { token?: string } = {},
+): Promise<number[]> {
+  const answer = await readAnswer(page, opts.token);
+  await setBoxes(page, answer);
+  await page.locator("[data-submit]").click();
+  return answer;
+}
+
+// Resolve all boxes to a deliberately wrong number and submit. Flips the units
+// digit so the guess stays a valid 3-digit number but is incorrect.
+export async function submitWrongGuess(
+  page: Page,
+  opts: { token?: string } = {},
+): Promise<number[]> {
+  const answer = await readAnswer(page, opts.token);
+  const wrong = [...answer];
+  wrong[2] = (answer[2] + 1) % 10;
+  await setBoxes(page, wrong);
+  await page.locator("[data-submit]").click();
+  return wrong;
+}

--- a/e2e/helpers/storage.ts
+++ b/e2e/helpers/storage.ts
@@ -1,0 +1,50 @@
+import type { Page } from "@playwright/test";
+
+// localStorage seeders for "returning user" scenarios. Each writes via
+// addInitScript so the state is present before the app boots, on every navigation
+// in the context. Shapes mirror src/storage.ts, src/theme.ts, src/colours.ts.
+
+export interface HistoryEntry {
+  date: string; // YYYY-MM-DD
+  tries: number;
+  answer?: number;
+}
+
+// Seed solve history (drives completion stats, streaks, "already played today").
+export async function seedHistory(page: Page, entries: HistoryEntry[]): Promise<void> {
+  await page.addInitScript((data) => {
+    localStorage.setItem("dlng_history", JSON.stringify(data));
+  }, entries);
+}
+
+// Seed preferences. Default app pref is { saveScore: true }.
+export async function seedPrefs(page: Page, prefs: { saveScore?: boolean } = {}): Promise<void> {
+  await page.addInitScript((data) => {
+    localStorage.setItem("dlng_prefs", JSON.stringify({ saveScore: true, ...data }));
+  }, prefs);
+}
+
+// Seed the analytics/beacon user id.
+export async function seedUid(page: Page, uid = "e2e-uid"): Promise<void> {
+  await page.addInitScript((id) => {
+    localStorage.setItem("dlng_uid", id);
+  }, uid);
+}
+
+// Seed theme ("dark" | "light") and/or accent colour name.
+export async function seedTheme(
+  page: Page,
+  opts: { theme?: "dark" | "light"; colour?: string } = {},
+): Promise<void> {
+  await page.addInitScript((o) => {
+    if (o.theme) localStorage.setItem("dlng_theme", o.theme);
+    if (o.colour) localStorage.setItem("dlng_colour", o.colour);
+  }, opts);
+}
+
+// Mark the player as having visited today (suppresses the stale-day rollover).
+export async function seedLastVisit(page: Page, date: string): Promise<void> {
+  await page.addInitScript((d) => {
+    localStorage.setItem("dlng_last_visit_date", d);
+  }, date);
+}

--- a/e2e/pages/archive.page.ts
+++ b/e2e/pages/archive.page.ts
@@ -1,0 +1,34 @@
+import type { Page, Locator } from "@playwright/test";
+
+// SSR /archive list page + the in-app dated replay banner. Thin page object.
+export class ArchivePage {
+  readonly rows: Locator;
+  readonly heading: Locator;
+  // Replay banner lives on the game screen once a dated puzzle is opened.
+  readonly replayRow: Locator;
+  readonly replayBanner: Locator;
+  readonly backBtn: Locator;
+
+  constructor(public readonly page: Page) {
+    this.rows = page.locator("tr.row");
+    this.heading = page.locator("h1");
+    this.replayRow = page.locator("[data-archive-row]");
+    this.replayBanner = page.locator("[data-archive-banner]");
+    this.backBtn = page.locator("[data-archive-back]");
+  }
+
+  async open(): Promise<void> {
+    await this.page.goto("/archive");
+  }
+
+  // The replay link in a row ("Play" button or the number cell anchor).
+  rowLink(date: string): Locator {
+    return this.page.locator(`tr.row[data-date="${date}"] a[href="/archive/${date}"]`).first();
+  }
+
+  // Read the date of the newest row (the archive sorts date-descending, so row 0
+  // is today).
+  async newestDate(): Promise<string> {
+    return (await this.rows.first().getAttribute("data-date")) ?? "";
+  }
+}

--- a/e2e/pages/completion.page.ts
+++ b/e2e/pages/completion.page.ts
@@ -1,0 +1,26 @@
+import type { Page, Locator } from "@playwright/test";
+
+// Completion screen (/solved). Thin page object: locators + actions only.
+export class CompletionPage {
+  readonly screen: Locator;
+  readonly heading: Locator;
+  readonly subheading: Locator;
+  readonly stats: Locator;
+  readonly countdown: Locator;
+  readonly feedbackBtn: Locator;
+  readonly links: Locator;
+
+  constructor(public readonly page: Page) {
+    this.screen = page.locator('[data-screen="completion"]');
+    this.heading = page.locator("[data-completion-heading]");
+    this.subheading = page.locator("[data-completion-subheading]");
+    this.stats = page.locator("[data-completion-stats]");
+    this.countdown = page.locator("[data-completion-countdown]");
+    this.feedbackBtn = page.locator("[data-completion-feedback]");
+    this.links = page.locator("[data-completion-links]");
+  }
+
+  async open(): Promise<void> {
+    await this.page.goto("/solved");
+  }
+}

--- a/e2e/pages/feedback.page.ts
+++ b/e2e/pages/feedback.page.ts
@@ -1,0 +1,22 @@
+import type { Page, Locator } from "@playwright/test";
+
+// Feedback modal (<dialog>). Thin page object.
+export class FeedbackPage {
+  readonly modal: Locator;
+  readonly cats: Locator;
+  readonly msg: Locator;
+  readonly send: Locator;
+  readonly close: Locator;
+
+  constructor(public readonly page: Page) {
+    this.modal = page.locator("[data-fb-modal]");
+    this.cats = page.locator("[data-fb-cats]");
+    this.msg = page.locator("[data-fb-msg]");
+    this.send = page.locator("[data-fb-send]");
+    this.close = page.locator("[data-fb-modal-close]");
+  }
+
+  cat(name: "bug" | "suggestion" | "praise"): Locator {
+    return this.page.locator(`[data-cat="${name}"]`);
+  }
+}

--- a/e2e/pages/game.page.ts
+++ b/e2e/pages/game.page.ts
@@ -1,0 +1,53 @@
+import type { Page, Locator } from "@playwright/test";
+
+// Game screen (/play). Thin page object: locators + actions only. Solve logic
+// lives in helpers/solve.ts so it can be shared and asserted on in specs.
+export class GamePage {
+  readonly screen: Locator;
+  readonly clueList: Locator;
+  readonly keypad: Locator;
+  readonly submit: Locator;
+  readonly feedback: Locator;
+  readonly archiveRow: Locator;
+  readonly archiveBanner: Locator;
+  readonly archiveBack: Locator;
+  readonly firstClueTag: Locator;
+  readonly tagTip: Locator;
+
+  constructor(public readonly page: Page) {
+    this.screen = page.locator('[data-screen="game"]');
+    this.clueList = page.locator("[data-clue-list]");
+    this.keypad = page.locator("[data-keypad]");
+    this.submit = page.locator("[data-submit]");
+    this.feedback = page.locator("[data-feedback]");
+    this.archiveRow = page.locator("[data-archive-row]");
+    this.archiveBanner = page.locator("[data-archive-banner]");
+    this.archiveBack = page.locator("[data-archive-back]");
+    this.firstClueTag = page.locator("[data-clue-tag]").first();
+    this.tagTip = page.locator("[data-tag-tip]");
+  }
+
+  async open(): Promise<void> {
+    await this.page.goto("/play");
+  }
+
+  digit(i: number): Locator {
+    return this.page.locator(`[data-digit="${i}"]`);
+  }
+
+  key(d: number): Locator {
+    return this.page.locator(`[data-key="${d}"]`);
+  }
+
+  async openBox(i: number): Promise<void> {
+    await this.digit(i).click();
+  }
+
+  async tapKey(d: number): Promise<void> {
+    await this.key(d).click();
+  }
+
+  async openFirstClueTip(): Promise<void> {
+    await this.firstClueTag.click();
+  }
+}

--- a/e2e/pages/menu.page.ts
+++ b/e2e/pages/menu.page.ts
@@ -1,0 +1,28 @@
+import type { Page, Locator } from "@playwright/test";
+
+// Header burger menu + its items. Thin page object.
+export class MenuPage {
+  readonly menuBtn: Locator;
+  readonly menu: Locator;
+  readonly fbBtn: Locator;
+  readonly htpBtn: Locator;
+  readonly themeToggle: Locator;
+  readonly swatches: Locator;
+
+  constructor(public readonly page: Page) {
+    this.menuBtn = page.locator("[data-menu-btn]");
+    this.menu = page.locator("[data-menu]");
+    this.fbBtn = page.locator("[data-menu] [data-fb-btn]");
+    this.htpBtn = page.locator("[data-menu] [data-htp-btn]");
+    this.themeToggle = page.locator("[data-theme-toggle]");
+    this.swatches = page.locator("[data-swatches]");
+  }
+
+  async open(): Promise<void> {
+    await this.menuBtn.click();
+  }
+
+  swatch(name: string): Locator {
+    return this.page.locator(`[data-swatches] [data-colour="${name}"]`);
+  }
+}

--- a/e2e/pages/welcome.page.ts
+++ b/e2e/pages/welcome.page.ts
@@ -1,0 +1,24 @@
+import type { Page, Locator } from "@playwright/test";
+
+// Welcome screen. Thin page object: locators + actions, no assertions.
+export class WelcomePage {
+  readonly screen: Locator;
+  readonly playBtn: Locator;
+
+  constructor(public readonly page: Page) {
+    this.screen = page.locator('[data-screen="welcome"]');
+    this.playBtn = page.locator("[data-play-btn]");
+  }
+
+  async open(): Promise<void> {
+    await this.page.goto("/welcome");
+  }
+
+  async openRoot(): Promise<void> {
+    await this.page.goto("/");
+  }
+
+  async play(): Promise<void> {
+    await this.playBtn.click();
+  }
+}

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -3,6 +3,7 @@ import AxeBuilder from "@axe-core/playwright";
 import { gotoPlayableGame } from "../helpers/game-setup.ts";
 import { seedHistory, seedLastVisit } from "../helpers/storage.ts";
 import { freezeDate } from "../helpers/clock.ts";
+import { waitForScreenSettled } from "../helpers/screens.ts";
 
 // Fail only on serious/critical violations — the launch-blocking bar. Lesser
 // (moderate/minor) findings are surfaced by a full `axe` run but don't gate here.
@@ -13,14 +14,31 @@ async function seriousViolations(page: import("@playwright/test").Page) {
     .map((v) => `${v.id} (${v.impact}): ${v.nodes.length} node(s)`);
 }
 
+// axe rules check the DOM/ARIA/contrast, which don't vary by rendering engine, so
+// run them on Chromium desktop + mobile (viewport coverage) rather than the whole
+// matrix. The behavioral specs still cover all 5 engines. This also removes the
+// flaky redundant axe runs that overload the single preview server.
+const A11Y_PROJECTS = ["chromium-desktop", "mobile-chromium"];
+
 test.describe("accessibility (axe — serious/critical)", () => {
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      !A11Y_PROJECTS.includes(testInfo.project.name),
+      "axe DOM/contrast checks are engine-independent — run on Chromium desktop + mobile",
+    );
+    // axe injects + analyses a large script in-page; give it headroom under load.
+    test.slow();
+  });
+
   test("welcome screen has no serious/critical violations", async ({ page }) => {
     await page.goto("/welcome");
+    await waitForScreenSettled(page, "welcome");
     expect(await seriousViolations(page)).toEqual([]);
   });
 
   test("game screen has no serious/critical violations", async ({ page }) => {
     await gotoPlayableGame(page);
+    await waitForScreenSettled(page, "game");
     expect(await seriousViolations(page)).toEqual([]);
   });
 
@@ -29,6 +47,7 @@ test.describe("accessibility (axe — serious/critical)", () => {
     await seedHistory(page, [{ date: "2026-06-08", tries: 2 }]);
     await seedLastVisit(page, "2026-06-08");
     await page.goto("/solved");
+    await waitForScreenSettled(page, "completion");
     await expect(page.locator("[data-completion-heading]")).toBeVisible();
     expect(await seriousViolations(page)).toEqual([]);
   });
@@ -39,9 +58,19 @@ test.describe("accessibility (axe — serious/critical)", () => {
     expect(await seriousViolations(page)).toEqual([]);
   });
 
-  test("keyboard: the skip-link is the first focusable control", async ({ page }) => {
+  test("the skip-link is present and (where supported) the first focusable control", async ({
+    page,
+    browserName,
+  }) => {
     await page.goto("/welcome");
+    const skip = page.locator("a.skip-link");
+    await expect(skip).toHaveAttribute("href", "#main");
+
+    // WebKit on macOS doesn't move Tab focus to links/buttons unless "Full Keyboard
+    // Access" is enabled, so the tab-order guarantee is only assertable on
+    // Chromium/Firefox. The link's presence + target is checked cross-browser above.
+    test.skip(browserName === "webkit", "WebKit doesn't Tab-focus links by default");
     await page.keyboard.press("Tab");
-    await expect(page.locator("a.skip-link")).toBeFocused();
+    await expect(skip).toBeFocused();
   });
 });

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "../fixtures.ts";
+import AxeBuilder from "@axe-core/playwright";
+import { gotoPlayableGame } from "../helpers/game-setup.ts";
+import { seedHistory, seedLastVisit } from "../helpers/storage.ts";
+import { freezeDate } from "../helpers/clock.ts";
+
+// Fail only on serious/critical violations — the launch-blocking bar. Lesser
+// (moderate/minor) findings are surfaced by a full `axe` run but don't gate here.
+async function seriousViolations(page: import("@playwright/test").Page) {
+  const results = await new AxeBuilder({ page }).analyze();
+  return results.violations
+    .filter((v) => v.impact === "serious" || v.impact === "critical")
+    .map((v) => `${v.id} (${v.impact}): ${v.nodes.length} node(s)`);
+}
+
+test.describe("accessibility (axe — serious/critical)", () => {
+  test("welcome screen has no serious/critical violations", async ({ page }) => {
+    await page.goto("/welcome");
+    expect(await seriousViolations(page)).toEqual([]);
+  });
+
+  test("game screen has no serious/critical violations", async ({ page }) => {
+    await gotoPlayableGame(page);
+    expect(await seriousViolations(page)).toEqual([]);
+  });
+
+  test("completion screen has no serious/critical violations", async ({ page }) => {
+    await freezeDate(page, "2026-06-08T12:00:00Z");
+    await seedHistory(page, [{ date: "2026-06-08", tries: 2 }]);
+    await seedLastVisit(page, "2026-06-08");
+    await page.goto("/solved");
+    await expect(page.locator("[data-completion-heading]")).toBeVisible();
+    expect(await seriousViolations(page)).toEqual([]);
+  });
+
+  test("archive page has no serious/critical violations", async ({ page }) => {
+    await page.goto("/archive");
+    await expect(page.locator("h1")).toBeVisible();
+    expect(await seriousViolations(page)).toEqual([]);
+  });
+
+  test("keyboard: the skip-link is the first focusable control", async ({ page }) => {
+    await page.goto("/welcome");
+    await page.keyboard.press("Tab");
+    await expect(page.locator("a.skip-link")).toBeFocused();
+  });
+});

--- a/e2e/specs/archive.spec.ts
+++ b/e2e/specs/archive.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../fixtures.ts";
+import { ArchivePage } from "../pages/archive.page.ts";
+import { solvePuzzle } from "../helpers/solve.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+
+// A valid past, in-range date that the Worker will serve a puzzle for.
+const PAST_DATE = "2026-03-10";
+
+test.describe("archive", () => {
+  test("SSR list loads with rows ordered newest-first", async ({ page }) => {
+    const archive = new ArchivePage(page);
+    await archive.open();
+    await expect(archive.heading).toContainText("Every Clumeral");
+
+    const count = await archive.rows.count();
+    expect(count).toBeGreaterThan(0);
+
+    const dates = await archive.rows.evaluateAll((rows) =>
+      rows.map((r) => r.getAttribute("data-date") ?? ""),
+    );
+    expect(dates).toEqual([...dates].sort().reverse()); // date-descending
+  });
+
+  test("deep-link to a dated puzzle shows the game with a replay banner", async ({ page }) => {
+    const archive = new ArchivePage(page);
+    await page.goto(`/archive/${PAST_DATE}`);
+
+    await expectActiveScreen(page, "game");
+    await expect(archive.replayRow).toBeVisible();
+    await expect(archive.replayBanner).not.toHaveText("");
+    await expect(archive.backBtn).toBeVisible();
+  });
+
+  test("the replay back button returns to /archive", async ({ page }) => {
+    const archive = new ArchivePage(page);
+    await page.goto(`/archive/${PAST_DATE}`);
+    await expect(archive.backBtn).toBeVisible();
+
+    await archive.backBtn.click();
+    expect(new URL(page.url()).pathname).toBe("/archive");
+    await expect(archive.heading).toContainText("Every Clumeral");
+  });
+
+  test("clicking the newest archive row opens its puzzle", async ({ page }) => {
+    const archive = new ArchivePage(page);
+    await archive.open();
+    const date = await archive.newestDate();
+    expect(date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    await archive.rowLink(date).click();
+    await expect(page).toHaveURL(new RegExp(`/archive/${date}$`));
+    await expectActiveScreen(page, "game");
+  });
+
+  test("solving today's replay reaches completion", async ({ page }) => {
+    // Today's archive replay loads /api/puzzle?date=<today>, whose answer matches
+    // /api/dev/answer (today, UTC) — so the solve helper can drive it to completion.
+    const { date } = (await (await page.request.get("/api/puzzle")).json()) as { date: string };
+    await page.goto(`/archive/${date}`);
+    await expectActiveScreen(page, "game");
+
+    await solvePuzzle(page);
+    await expectActiveScreen(page, "completion");
+  });
+});

--- a/e2e/specs/completion.spec.ts
+++ b/e2e/specs/completion.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "../fixtures.ts";
+import { CompletionPage } from "../pages/completion.page.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+import { seedHistory, seedLastVisit } from "../helpers/storage.ts";
+import { freezeDate } from "../helpers/clock.ts";
+
+// Frozen "today" so seeded history and the countdown are deterministic.
+const NOW = "2026-06-08T12:00:00Z";
+const TODAY = "2026-06-08";
+
+// Three consecutive days ending today: played=3, avg=(2+4+3)/3=3.0, streak=3.
+const HISTORY = [
+  { date: "2026-06-08", tries: 2 },
+  { date: "2026-06-07", tries: 4 },
+  { date: "2026-06-06", tries: 3 },
+];
+
+async function gotoCompletion(page: import("@playwright/test").Page) {
+  await freezeDate(page, NOW);
+  await seedHistory(page, HISTORY);
+  await seedLastVisit(page, TODAY);
+  await page.goto("/solved");
+  await expectActiveScreen(page, "completion");
+}
+
+test.describe("completion screen", () => {
+  test("stats render from seeded history", async ({ page }) => {
+    await gotoCompletion(page);
+    const stat = (label: string) =>
+      page.locator("[data-completion-stats] > div").filter({ hasText: label }).locator("span.font-mono");
+
+    await expect(stat("Played")).toHaveText("3");
+    await expect(stat("Avg tries")).toHaveText("3.0");
+    await expect(page.locator("[data-completion-stats] > div")).toHaveCount(4);
+  });
+
+  test("countdown shows the time until the next puzzle, derived from the clock", async ({ page }) => {
+    // Rendered once from the frozen clock (not a live tick). NOW = 12:00 UTC, next
+    // local midnight is 24:00, so ~12h remain. Assert the format and that it derives
+    // from the clock (11h/12h band) rather than a hardcoded value — exact minutes
+    // drift by sub-second clock skew, so don't pin them.
+    await gotoCompletion(page);
+    const completion = new CompletionPage(page);
+
+    await expect(completion.countdown).toBeVisible();
+    await expect(completion.countdown).toHaveText(/^Next puzzle in (11|12)h \d{1,2}m$/);
+  });
+
+  test("completion links and feedback button are present", async ({ page }) => {
+    await gotoCompletion(page);
+    const completion = new CompletionPage(page);
+
+    await expect(completion.links).toBeVisible();
+    await expect(completion.links.locator("a, button")).not.toHaveCount(0);
+    await expect(completion.feedbackBtn).toBeVisible();
+  });
+});

--- a/e2e/specs/game-fail.spec.ts
+++ b/e2e/specs/game-fail.spec.ts
@@ -18,14 +18,23 @@ test.describe("game — wrong guess", () => {
     await expectActiveScreen(page, "game");
   });
 
-  test("the submit button re-enables after a wrong guess (no stuck state)", async ({ page }) => {
+  test("after a wrong guess submit hides but is not stuck — a box re-engages to retry", async ({ page }) => {
     await gotoPlayableGame(page);
     const game = new GamePage(page);
 
     await submitWrongGuess(page);
+    // Wait for the guess handler to finish (feedback paints in the same branch that
+    // hides submit), so we assert settled state, not the in-flight race.
+    await expect(game.feedback).toBeVisible();
 
-    // Boxes stay resolved, so submit stays available and clickable for a retry.
-    await expect(game.submit).toBeVisible();
+    // Real behavior (app.ts: wrong branch hides submitWrap): submit is hidden after
+    // a wrong guess; the player re-engages a box to try again.
+    await expect(game.submit).toBeHidden();
+    // But it is NOT stuck in the submitting state — the disabled flag is cleared.
     await expect(game.submit).toBeEnabled();
+
+    // Re-opening a box reopens the keypad, so a retry is possible (no dead end).
+    await game.openBox(0);
+    await expect(game.keypad).toBeVisible();
   });
 });

--- a/e2e/specs/game-fail.spec.ts
+++ b/e2e/specs/game-fail.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "../fixtures.ts";
+import { GamePage } from "../pages/game.page.ts";
+import { gotoPlayableGame } from "../helpers/game-setup.ts";
+import { submitWrongGuess } from "../helpers/solve.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+
+test.describe("game — wrong guess", () => {
+  test("a wrong guess shows feedback and stays on the game screen", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const game = new GamePage(page);
+
+    await submitWrongGuess(page);
+
+    // Feedback message appears (data-feedback un-hides) and we have NOT advanced
+    // to completion — still on the game screen.
+    await expect(game.feedback).toBeVisible();
+    await expect(game.feedback).not.toHaveText("");
+    await expectActiveScreen(page, "game");
+  });
+
+  test("the submit button re-enables after a wrong guess (no stuck state)", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const game = new GamePage(page);
+
+    await submitWrongGuess(page);
+
+    // Boxes stay resolved, so submit stays available and clickable for a retry.
+    await expect(game.submit).toBeVisible();
+    await expect(game.submit).toBeEnabled();
+  });
+});

--- a/e2e/specs/game-solve.spec.ts
+++ b/e2e/specs/game-solve.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "../fixtures.ts";
+import { GamePage } from "../pages/game.page.ts";
+import { gotoPlayableGame } from "../helpers/game-setup.ts";
+import { solvePuzzle } from "../helpers/solve.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+
+type HistoryEntry = { date: string; tries: number; answer?: number };
+
+const readHistory = (page: import("@playwright/test").Page) =>
+  page.evaluate(
+    () => JSON.parse(localStorage.getItem("dlng_history") || "[]") as HistoryEntry[],
+  );
+
+test.describe("game — solving", () => {
+  test("solving the daily puzzle reaches completion and records history", async ({ page }) => {
+    await gotoPlayableGame(page);
+    await solvePuzzle(page);
+
+    await expectActiveScreen(page, "completion");
+    await expect(page.locator("[data-completion-heading]")).toBeVisible();
+
+    // Seeded one past entry; solving today appends a second, keyed on today's date.
+    const history = await readHistory(page);
+    expect(history).toHaveLength(2);
+    const fresh = history.filter((e) => e.date !== "2026-01-01");
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("eliminating down to one digit locks the box; the last digit cannot be removed", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const game = new GamePage(page);
+
+    await game.openBox(1);
+    // Eliminate every candidate except 7.
+    for (const d of [0, 1, 2, 3, 4, 5, 6, 8, 9]) await game.tapKey(d);
+    await expect(page.locator('[data-digit="1"] span')).toHaveText("7");
+
+    // The "cannot eliminate the last digit" guard: tapping 7 again is a no-op.
+    await game.tapKey(7);
+    await expect(page.locator('[data-digit="1"] span')).toHaveText("7");
+  });
+
+  test("submit appears only when all three boxes are resolved", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const game = new GamePage(page);
+
+    await game.openBox(0);
+    for (const d of [2, 3, 4, 5, 6, 7, 8, 9]) await game.tapKey(d); // box 0 → 1
+    await expect(game.submit).toBeHidden();
+
+    await game.openBox(1);
+    for (const d of [0, 1, 3, 4, 5, 6, 7, 8, 9]) await game.tapKey(d); // box 1 → 2
+    await expect(game.submit).toBeHidden();
+
+    await game.openBox(2);
+    for (const d of [0, 1, 2, 4, 5, 6, 7, 8, 9]) await game.tapKey(d); // box 2 → 3
+    await expect(game.submit).toBeVisible();
+  });
+
+  test("tapping a clue tag opens its definition tooltip", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const game = new GamePage(page);
+
+    await expect(game.firstClueTag).toBeVisible(); // clues finished loading
+    await game.openFirstClueTip();
+    await expect(game.tagTip).toBeVisible();
+  });
+});

--- a/e2e/specs/menu.spec.ts
+++ b/e2e/specs/menu.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "../fixtures.ts";
+import { MenuPage } from "../pages/menu.page.ts";
+import { FeedbackPage } from "../pages/feedback.page.ts";
+import { gotoPlayableGame } from "../helpers/game-setup.ts";
+
+test.describe("header menu", () => {
+  test("burger toggles the menu and flips aria-expanded; Esc closes it", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const menu = new MenuPage(page);
+
+    await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
+    await menu.open();
+    await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "true");
+    await expect(menu.menu).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("feedback modal: open, fill, send (stubbed) shows a success toast", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const menu = new MenuPage(page);
+    const fb = new FeedbackPage(page);
+
+    await menu.open();
+    await menu.fbBtn.click();
+    await expect(fb.modal).toBeVisible();
+
+    await fb.cat("bug").click();
+    await fb.msg.fill("E2E smoke feedback — please ignore.");
+    await fb.send.click();
+
+    // Send POSTs to the stubbed Apps Script (200) → success toast.
+    await expect(page.locator("[data-toast] .toast-msg")).toBeVisible();
+  });
+
+  test("theme toggle flips the root class and persists across reload", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const menu = new MenuPage(page);
+    const root = page.locator("html");
+
+    const wasDark = await root.evaluate((el) => el.classList.contains("dark"));
+    const expected = wasDark ? /light/ : /dark/;
+
+    await menu.open();
+    await menu.themeToggle.click();
+    await expect(root).toHaveClass(expected);
+
+    await page.reload();
+    await expect(root).toHaveClass(expected);
+    expect(await page.evaluate(() => localStorage.getItem("dlng_theme"))).toBe(
+      wasDark ? "light" : "dark",
+    );
+  });
+
+  test("colour swatch selection persists across reload", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const menu = new MenuPage(page);
+
+    await menu.open();
+    await menu.swatch("Berry").click();
+    expect(await page.evaluate(() => localStorage.getItem("dlng_colour"))).toBe("Berry");
+
+    await page.reload();
+    expect(await page.evaluate(() => localStorage.getItem("dlng_colour"))).toBe("Berry");
+  });
+});

--- a/e2e/specs/menu.spec.ts
+++ b/e2e/specs/menu.spec.ts
@@ -17,7 +17,7 @@ test.describe("header menu", () => {
     await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
   });
 
-  test("feedback modal: open, fill, send (stubbed) shows a success toast", async ({ page }) => {
+  test("feedback modal: open, fill, send (stubbed) succeeds and closes", async ({ page }) => {
     await gotoPlayableGame(page);
     const menu = new MenuPage(page);
     const fb = new FeedbackPage(page);
@@ -30,7 +30,11 @@ test.describe("header menu", () => {
     await fb.msg.fill("E2E smoke feedback — please ignore.");
     await fb.send.click();
 
-    // Send POSTs to the stubbed Apps Script (200) → success toast.
+    // Success (the fixture stubs script.google.com → 200) closes the modal — a
+    // persistent signal, unlike the toast which self-removes after 3s (flaky to
+    // assert under load). If the stub ever misses, the client logs a non-allowlisted
+    // console.error and the guard fails the test — the correct signal.
+    await expect(fb.modal).toBeHidden();
     await expect(page.locator("[data-toast] .toast-msg")).toBeVisible();
   });
 

--- a/e2e/specs/routing.spec.ts
+++ b/e2e/specs/routing.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../fixtures.ts";
+import { WelcomePage } from "../pages/welcome.page.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+import { seedHistory } from "../helpers/storage.ts";
+
+test.describe("routing", () => {
+  test("history.scrollRestoration is set to 'manual' at boot", async ({ page }) => {
+    await page.goto("/");
+    expect(await page.evaluate(() => history.scrollRestoration)).toBe("manual");
+  });
+
+  test("back/forward popstate re-renders the correct screen", async ({ page }) => {
+    // Seed a past entry so /play resolves to the game (hasData, no today entry) and
+    // the first-play walkthrough stays off.
+    await seedHistory(page, [{ date: "2026-01-01", tries: 2 }]);
+    const welcome = new WelcomePage(page);
+
+    await welcome.open();
+    await expectActiveScreen(page, "welcome");
+
+    await welcome.play();
+    await expectActiveScreen(page, "game");
+    expect(new URL(page.url()).pathname).toBe("/play");
+
+    await page.goBack();
+    await expectActiveScreen(page, "welcome");
+    expect(new URL(page.url()).pathname).toBe("/welcome");
+
+    await page.goForward();
+    await expectActiveScreen(page, "game");
+    expect(new URL(page.url()).pathname).toBe("/play");
+  });
+
+  // Deferred (fragile / lower value): the /archive SSR-handoff analytics beacon and
+  // the visibility/focus stale-day rollover. Tracked for a later pass — see the QA
+  // regression design spec. They depend on document-unload beacon timing and
+  // tab-visibility emulation that are flaky across the browser matrix.
+});

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "../fixtures.ts";
+
+// Smoke: every user-reachable route loads without erroring, with its primary
+// element present and the console guard clean. SPA routes serve the app shell;
+// /archive and /stats are Worker-rendered; /puzzles 302s to /archive.
+
+test.describe("smoke: routes load clean", () => {
+  test("/ serves the app shell", async ({ page }) => {
+    const res = await page.goto("/");
+    expect(res?.status()).toBeLessThan(400);
+    await expect(page.locator("[data-screens]")).toBeAttached();
+  });
+
+  test("/play serves the app shell", async ({ page }) => {
+    // A cold visitor with no history bounces to /welcome (RTE-03) — either way the
+    // shell loads. Smoke only asserts the shell + a clean console.
+    const res = await page.goto("/play");
+    expect(res?.status()).toBeLessThan(400);
+    await expect(page.locator("[data-screens]")).toBeAttached();
+  });
+
+  test("/solved serves the app shell", async ({ page }) => {
+    const res = await page.goto("/solved");
+    expect(res?.status()).toBeLessThan(400);
+    await expect(page.locator("[data-screens]")).toBeAttached();
+  });
+
+  test("/archive renders the SSR list", async ({ page }) => {
+    const res = await page.goto("/archive");
+    expect(res?.status()).toBeLessThan(400);
+    await expect(page.locator("h1")).toContainText("Every Clumeral");
+  });
+
+  test("/puzzles redirects to /archive", async ({ page }) => {
+    await page.goto("/puzzles");
+    expect(new URL(page.url()).pathname).toBe("/archive");
+    await expect(page.locator("h1")).toContainText("Every Clumeral");
+  });
+
+  test("/stats renders the dashboard or the documented 503", async ({ page }) => {
+    // Local preview usually lacks analytics secrets → documented 503. With secrets
+    // present it renders the dashboard. Assert the documented either/or.
+    const res = await page.goto("/stats");
+    const status = res?.status() ?? 0;
+    expect([200, 503]).toContain(status);
+    if (status === 200) {
+      await expect(page.locator("h1")).toContainText("Clumeral Stats");
+    } else {
+      await expect(page.locator("body")).toContainText("Analytics secrets not configured");
+    }
+  });
+});

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -37,16 +37,15 @@ test.describe("smoke: routes load clean", () => {
     await expect(page.locator("h1")).toContainText("Every Clumeral");
   });
 
-  test("/stats renders the dashboard or the documented 503", async ({ page }) => {
-    // Local preview usually lacks analytics secrets → documented 503. With secrets
-    // present it renders the dashboard. Assert the documented either/or.
-    const res = await page.goto("/stats");
-    const status = res?.status() ?? 0;
-    expect([200, 503]).toContain(status);
-    if (status === 200) {
-      await expect(page.locator("h1")).toContainText("Clumeral Stats");
-    } else {
-      await expect(page.locator("body")).toContainText("Analytics secrets not configured");
-    }
+  test("/stats serves the dashboard or the documented 503", async ({ page }) => {
+    // Checked at the request level: a browser navigation to the 503 fallback would
+    // log an (expected) resource-load console error, which the guard shouldn't have
+    // to allowlist. Local preview usually lacks analytics secrets → documented 503;
+    // with secrets it renders the dashboard.
+    const res = await page.request.get("/stats");
+    expect([200, 503]).toContain(res.status());
+    const body = await res.text();
+    if (res.status() === 200) expect(body).toContain("Clumeral Stats");
+    else expect(body).toContain("Analytics secrets not configured");
   });
 });

--- a/e2e/specs/ssr-pages.spec.ts
+++ b/e2e/specs/ssr-pages.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "../fixtures.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+
+test.describe("SSR / shell routes", () => {
+  test("/stats serves the dashboard or the documented 503", async ({ request }) => {
+    const res = await request.get("/stats");
+    expect([200, 503]).toContain(res.status());
+    if (res.status() === 503) {
+      expect(await res.text()).toContain("Analytics secrets not configured");
+    }
+  });
+
+  test("/puzzles/<date> redirects to /archive/<date>", async ({ page }) => {
+    await page.goto("/puzzles/2026-03-10");
+    expect(new URL(page.url()).pathname).toBe("/archive/2026-03-10");
+    await expectActiveScreen(page, "game");
+  });
+
+  test("/puzzles/<num> redirects into the archive replay", async ({ page }) => {
+    await page.goto("/puzzles/1");
+    expect(new URL(page.url()).pathname).toMatch(/^\/archive\/\d{4}-\d{2}-\d{2}$/);
+    await expectActiveScreen(page, "game");
+  });
+
+  test("/random serves the app shell and starts a random puzzle", async ({ page }) => {
+    await page.goto("/random");
+    await expectActiveScreen(page, "game");
+    await expect(page.locator("[data-clue-list]")).toBeVisible();
+  });
+});

--- a/e2e/specs/welcome.spec.ts
+++ b/e2e/specs/welcome.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "../fixtures.ts";
+import { WelcomePage } from "../pages/welcome.page.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+import { seedHistory, seedLastVisit } from "../helpers/storage.ts";
+
+test.describe("welcome screen", () => {
+  test("first visit shows the welcome screen with a Play CTA", async ({ page }) => {
+    const welcome = new WelcomePage(page);
+    await welcome.open();
+    await expectActiveScreen(page, "welcome");
+    await expect(welcome.playBtn).toBeVisible();
+  });
+
+  test("clicking Play navigates to the game screen", async ({ page }) => {
+    const welcome = new WelcomePage(page);
+    await welcome.open();
+    await welcome.play();
+    await expectActiveScreen(page, "game");
+    await expect(page.locator("[data-clue-list]")).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe("/play");
+  });
+
+  test("cold deep-link to /play with a stale last-visit redirects to /welcome", async ({ page }) => {
+    // Stale-day rollover (router cold-load): a prior visit date older than today
+    // forces /welcome so the player never sees a stale board. Seed history so the
+    // resolver would otherwise allow /play — proving the rollover is what redirects.
+    await seedHistory(page, [{ date: "2026-01-01", tries: 2 }]);
+    await seedLastVisit(page, "2026-01-01");
+    await page.goto("/play");
+    await expectActiveScreen(page, "welcome");
+    expect(new URL(page.url()).pathname).toBe("/welcome");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@cloudflare/vite-plugin": "^1.31.0",
         "@cloudflare/workers-types": "^4.20260403.1",
         "@playwright/test": "~1.60",
@@ -36,6 +37,19 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -2430,6 +2444,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://clumeral.com",
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@cloudflare/vite-plugin": "^1.31.0",
     "@cloudflare/workers-types": "^4.20260403.1",
     "@playwright/test": "~1.60",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,17 @@ import { defineConfig, devices } from "@playwright/test";
 // Test what ships.
 const PORT = 4173;
 
+// The structured regression suite lives in e2e/specs/** and runs across the full
+// browser matrix. The older ad-hoc specs sit in e2e/ root and stay chromium-only
+// (their original scope) so the matrix doesn't change their behaviour.
+const SUITE = /specs[\\/].*\.spec\.ts$/;
+const LEGACY = /e2e[\\/][^\\/]+\.spec\.ts$/;
+
+// Deterministic clock context for the suite: UTC so the browser-local day matches
+// the worker's todayUTC() (which /api/dev/answer keys on). Specs that test timezone
+// divergence override timezoneId per-describe.
+const SUITE_USE = { timezoneId: "UTC", locale: "en-GB" } as const;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -20,7 +31,14 @@ export default defineConfig({
     reducedMotion: "no-preference",
   },
   projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    // ── Structured regression suite — full browser matrix ──
+    { name: "chromium-desktop", testMatch: SUITE, use: { ...devices["Desktop Chrome"], ...SUITE_USE } },
+    { name: "webkit-desktop", testMatch: SUITE, use: { ...devices["Desktop Safari"], ...SUITE_USE } },
+    { name: "firefox-desktop", testMatch: SUITE, use: { ...devices["Desktop Firefox"], ...SUITE_USE } },
+    { name: "mobile-chromium", testMatch: SUITE, use: { ...devices["Pixel 5"], ...SUITE_USE } },
+    { name: "mobile-webkit", testMatch: SUITE, use: { ...devices["iPhone 13"], ...SUITE_USE } },
+    // ── Existing ad-hoc specs — chromium only, unchanged scope ──
+    { name: "legacy-chromium", testMatch: LEGACY, use: { ...devices["Desktop Chrome"] } },
   ],
   webServer: {
     // `preview` = `vite build && vite preview`. Always rebuild before serving —


### PR DESCRIPTION
Implements the [QA regression design spec](docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md). Roadmap "Now" item; unblocks #213.

## What

A structured Playwright E2E suite covering every user-reachable flow, run against the **production build** (`vite preview` + local Worker) to catch build-only bugs.

- **38 specs** in `e2e/specs/`, green on the **full 5-engine matrix** (chromium / webkit / firefox desktop + mobile chromium / webkit): **175 passed, 0 failed**, stable across repeated runs.
- Existing ad-hoc specs (midnight-rollover, octopus-walkthrough, octo-celebration, pwa-render) kept untouched under a `legacy-chromium` project.

## Coverage

| Spec | Covers |
|------|--------|
| `smoke` | every route loads clean (/, /play, /solved, /archive, /puzzles, /stats) |
| `welcome` | first-visit CTA, Play→game, stale-day cold rollover |
| `game-solve` | solve→completion+history, eliminate-to-lock + last-digit guard, submit enablement, clue tooltip |
| `game-fail` | wrong guess shows feedback, stays on /play, submit hides + not stuck |
| `completion` | stats from seeded history, clock-derived countdown, links |
| `archive` | SSR list + order, dated replay banner + back, solve today's replay |
| `menu` | burger toggle + aria, feedback (stubbed)→close, theme + colour persist |
| `routing` | scrollRestoration='manual', back/forward popstate |
| `ssr-pages` | /stats 200-or-503, /puzzles redirects, /random |
| `a11y` | axe (serious/critical) on welcome/game/completion/archive, skip-link |

## Infra

- `fixtures.ts` — auto console guard (fails on console.error/pageerror) + feedback network stub.
- `helpers/` — real keypad-driven solve via `/api/dev/answer`, clock, storage seeders, screen-state + settle waits.
- `pages/` — thin page objects (locators + actions, no assertions).
- New dev dep: `@axe-core/playwright`.

## Determinism notes

- Suite contexts pinned to UTC so browser-local day == worker `todayUTC()`.
- axe runs on Chromium desktop + mobile only (engine-independent DOM/contrast); behavioral specs cover all 5 engines.
- No production code touched. `/api/dev/answer` is 404'd on clumeral.com — used only against local preview.

## Reviewed

- Fresh-context DA review → fixed one false-confidence test (game-fail submit) and tightened the console-guard allowlist.
- Self-review: tsc clean, no `.only`/`console.log`, all page objects used.

## Deferred (noted in the spec)

The /archive SSR-handoff analytics beacon assertion and the visibility/focus stale-day rollover test — fragile timing, lower value. Tracked for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)