### PR TITLE
feat(feedback): migrate feedback to Cloudflare D1 (#213)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ NEW_IMAGES/
 
 # Local Worker secrets (never commit)
 .dev.vars
+
+# One-off data import — real user feedback, never commit to the repo
+migrations/0002_import_legacy_feedback.sql

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ npm-debug.log*
 
 # Image export scratch (Figma exports, processed then removed)
 NEW_IMAGES/
+
+# Local Worker secrets (never commit)
+.dev.vars

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@ Rules that keep it from rotting:
 
 ## Now — WIP 1
 
-- [#213](https://github.com/jevawin/clumeral-game/issues/213) Supabase feedback migration — now unblocked (QA suite green); the one-line feedback-intercept swap is covered by `e2e/specs/menu.spec.ts`. `when:` QA suite branch merges.
+- [#213](https://github.com/jevawin/clumeral-game/issues/213) Feedback migration → **Cloudflare D1** (not Supabase — free-tier project cap + no external dep). Same-origin `POST /api/feedback` Worker route + token-guarded admin list; client swapped off the Google Apps Script URL. Built on branch `issue/213-d1-feedback`, e2e green. `when:` PR `issue/213-d1-feedback → new-design` review passes.
 
 ## Recently shipped
 

--- a/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
+++ b/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
@@ -103,9 +103,11 @@ where copy IS the thing under test.
 
 ### External calls — stub at the network boundary
 
-- **Feedback** → `page.route('**/script.google.com/**', fulfil 200)`. Real client send
-  code runs; nothing leaves the machine. *When #213 (Supabase feedback) lands, change the
-  intercept to the new same-origin `POST /api/feedback` and drop the Google pattern.*
+- **Feedback** → as of #213, no network stub. The client POSTs same-origin to
+  `/api/feedback`, served by the real preview Worker writing to a **local** miniflare D1
+  (seeded by `npm run e2e:db`). Nothing leaves the machine and the actual route + insert
+  get exercised. (An active service worker also makes `page.route` interception unreliable
+  on WebKit, which is the other reason to hit the real local endpoint rather than stub it.)
 - **Analytics** → the local preview Worker already isolates `/api/event` writes (local
   Analytics Engine binding, not prod). No code change. Where a test asserts an event fired,
   `page.route('**/api/event')` to count/inspect the POST, then `continue` or `fulfil`.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,25 +1,22 @@
 import { test as base, expect } from "@playwright/test";
 import { attachConsoleGuard, type ConsoleGuard } from "./helpers/console.ts";
 
-// Custom `test` for the structured suite. Every test gets:
-//  - a console guard that fails the test on unexpected console.error / pageerror
-//    in built output (real regressions), and
-//  - the external feedback endpoint stubbed at the network boundary, so the real
-//    client send code runs but nothing leaves the machine.
+// Custom `test` for the structured suite. Every test gets a console guard that
+// fails the test on unexpected console.error / pageerror in built output (real
+// regressions).
+//
+// Feedback (#213) POSTs same-origin to /api/feedback and is served by the real
+// preview Worker writing to a LOCAL miniflare D1 (seeded by `npm run e2e:db`,
+// wired into the webServer command). Nothing leaves the machine, and the actual
+// Worker route + D1 insert get exercised — so there's no network stub here. (An
+// active service worker makes page.route interception unreliable on WebKit, which
+// is the other reason to hit the real local endpoint rather than stub it.)
 //
 // Import { test, expect } from "../fixtures.ts" in specs under e2e/specs/.
 export const test = base.extend<{ consoleGuard: ConsoleGuard }>({
   consoleGuard: [
     async ({ page }, use) => {
       const guard = attachConsoleGuard(page);
-
-      // Feedback → Google Apps Script. Fulfil 200 so the client's success path runs;
-      // no real network call leaves. When #213 (Supabase feedback) lands, swap this
-      // for the same-origin POST /api/feedback and drop the Google pattern.
-      await page.route("**/script.google.com/**", (route) =>
-        route.fulfill({ status: 200, contentType: "application/json", body: "{}" }),
-      );
-
       await use(guard);
       guard.assertClean();
     },

--- a/e2e/specs/menu.spec.ts
+++ b/e2e/specs/menu.spec.ts
@@ -17,7 +17,7 @@ test.describe("header menu", () => {
     await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
   });
 
-  test("feedback modal: open, fill, send (stubbed) succeeds and closes", async ({ page }) => {
+  test("feedback modal: open, fill, send succeeds and closes", async ({ page }) => {
     await gotoPlayableGame(page);
     const menu = new MenuPage(page);
     const fb = new FeedbackPage(page);
@@ -30,10 +30,10 @@ test.describe("header menu", () => {
     await fb.msg.fill("E2E smoke feedback — please ignore.");
     await fb.send.click();
 
-    // Success (the fixture stubs script.google.com → 200) closes the modal — a
-    // persistent signal, unlike the toast which self-removes after 3s (flaky to
-    // assert under load). If the stub ever misses, the client logs a non-allowlisted
-    // console.error and the guard fails the test — the correct signal.
+    // Success closes the modal — a persistent signal, unlike the toast which
+    // self-removes after 3s (flaky to assert under load). The send hits the real
+    // preview Worker → local D1 (seeded by e2e:db); a non-200 makes the client log
+    // a non-allowlisted console.error and the guard fails the test — the right signal.
     await expect(fb.modal).toBeHidden();
     await expect(page.locator("[data-toast] .toast-msg")).toBeVisible();
   });

--- a/migrations/0001_create_feedback.sql
+++ b/migrations/0001_create_feedback.sql
@@ -1,5 +1,5 @@
 -- Feedback submissions. Replaces the Google Apps Script endpoint (#213).
--- Written by the Worker (POST /api/feedback); read by the admin view (GET /api/feedback).
+-- Written by the Worker (POST /api/feedback); read by the admin view (GET /feedback).
 CREATE TABLE IF NOT EXISTS feedback (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
@@ -16,7 +16,10 @@ CREATE TABLE IF NOT EXISTS feedback (
   active        TEXT,
   tz_offset     INTEGER,
   local_today   TEXT,
-  screen        TEXT
+  screen        TEXT,
+  -- Request hostname at submit time (server-set). clumeral.com = real;
+  -- *.workers.dev / localhost = test/preview. Drives the admin default filter.
+  host          TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_feedback_created_at ON feedback (created_at DESC);

--- a/migrations/0001_create_feedback.sql
+++ b/migrations/0001_create_feedback.sql
@@ -1,0 +1,22 @@
+-- Feedback submissions. Replaces the Google Apps Script endpoint (#213).
+-- Written by the Worker (POST /api/feedback); read by the admin view (GET /api/feedback).
+CREATE TABLE IF NOT EXISTS feedback (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+  category      TEXT    NOT NULL,
+  message       TEXT    NOT NULL,
+  puzzle_number TEXT,
+  puzzle_date   TEXT,
+  device        TEXT,
+  browser       TEXT,
+  user_agent    TEXT,
+  -- Raw localStorage strings, forwarded unparsed for server-side reproduction.
+  history       TEXT,
+  prefs         TEXT,
+  active        TEXT,
+  tz_offset     INTEGER,
+  local_today   TEXT,
+  screen        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_created_at ON feedback (created_at DESC);

--- a/migrations/0003_add_host_column.sql
+++ b/migrations/0003_add_host_column.sql
@@ -1,0 +1,6 @@
+-- Add the host column to an already-created feedback table (#213).
+-- For fresh DBs the column is in 0001; this is for the remote D1 that predates it.
+-- Backfill existing rows to clumeral.com — all prior feedback (incl. the legacy
+-- import) came from production.
+ALTER TABLE feedback ADD COLUMN host TEXT;
+UPDATE feedback SET host = 'clumeral.com' WHERE host IS NULL;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e:ui": "playwright test --ui",
     "build": "vite build",
     "preview": "vite build && vite preview --host --port 4173",
-    "e2e:db": "wrangler d1 execute clumeral-feedback --local --file=migrations/0001_create_feedback.sql && wrangler d1 execute clumeral-feedback --local --command=\"DELETE FROM feedback;\"",
+    "e2e:db": "wrangler d1 execute clumeral-feedback --local --command=\"DROP TABLE IF EXISTS feedback;\" && wrangler d1 execute clumeral-feedback --local --file=migrations/0001_create_feedback.sql",
     "e2e:serve": "npm run e2e:db && npm run preview",
     "db:migrate:remote": "wrangler d1 execute clumeral-feedback --remote --file=migrations/0001_create_feedback.sql",
     "deploy": "cd dist/clumeral_game && npx wrangler deploy --config wrangler.json"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:e2e:ui": "playwright test --ui",
     "build": "vite build",
     "preview": "vite build && vite preview --host --port 4173",
+    "e2e:db": "wrangler d1 execute clumeral-feedback --local --file=migrations/0001_create_feedback.sql",
+    "e2e:serve": "npm run e2e:db && npm run preview",
     "deploy": "cd dist/clumeral_game && npx wrangler deploy --config wrangler.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test:e2e:ui": "playwright test --ui",
     "build": "vite build",
     "preview": "vite build && vite preview --host --port 4173",
-    "e2e:db": "wrangler d1 execute clumeral-feedback --local --file=migrations/0001_create_feedback.sql",
+    "e2e:db": "wrangler d1 execute clumeral-feedback --local --file=migrations/0001_create_feedback.sql && wrangler d1 execute clumeral-feedback --local --command=\"DELETE FROM feedback;\"",
     "e2e:serve": "npm run e2e:db && npm run preview",
+    "db:migrate:remote": "wrangler d1 execute clumeral-feedback --remote --file=migrations/0001_create_feedback.sql",
     "deploy": "cd dist/clumeral_game && npx wrangler deploy --config wrangler.json"
   },
   "repository": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,10 +41,12 @@ export default defineConfig({
     { name: "legacy-chromium", testMatch: LEGACY, use: { ...devices["Desktop Chrome"] } },
   ],
   webServer: {
-    // `preview` = `vite build && vite preview`. Always rebuild before serving —
-    // this suite exists to test BUILT output, so reusing a stale preview server
-    // (an older dist) would give false green/red. Never reuse.
-    command: "npm run preview",
+    // `e2e:serve` = seed the local D1 feedback table (`e2e:db`, idempotent) then
+    // `vite build && vite preview`. Always rebuild before serving — this suite
+    // exists to test BUILT output, so reusing a stale preview server (an older
+    // dist) would give false green/red. Never reuse. The D1 seed lets the real
+    // Worker serve POST /api/feedback locally (#213) instead of a network stub.
+    command: "npm run e2e:serve",
     url: `http://localhost:${PORT}`,
     reuseExistingServer: false,
     timeout: 120_000,

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -3,7 +3,8 @@
 
 import { todayKey } from './date.ts';
 
-const FEEDBACK_URL = "https://script.google.com/macros/s/AKfycbymbf3ukZNtmZLm9Qbffecjbyoy5-gUq1QWlWrUKT4Jteul4u7A93wBZJvT0WDoF9a6pg/exec";
+// Same-origin Worker route — inserts the submission into D1 (#213).
+const FEEDBACK_URL = "/api/feedback";
 
 // ─── Debug payload ────────────────────────────────────────────────────────────
 
@@ -199,21 +200,23 @@ export function initFeedbackModal(
       try {
         const res = await fetch(FEEDBACK_URL, {
           method: "POST",
-          mode: "no-cors",
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         });
-        // no-cors returns opaque response; if no error thrown, it succeeded
-        if (res.ok || res.type === "opaque") {
+        // Same-origin endpoint returns a real (non-opaque) response now.
+        if (res.ok) {
           closeFeedback();
           setTimeout(resetForm, 300);
           showToast("Thanks! Feedback sent.");
           return;
         }
-      } catch (err) {
-        if (attempt < MAX_RETRIES) {
-          await new Promise(r => setTimeout(r, 1000 * attempt));
-          continue;
-        }
+        // 4xx is a client-side problem — retrying won't help, so stop early.
+        if (res.status >= 400 && res.status < 500) break;
+      } catch {
+        // network error — fall through to backoff + retry
+      }
+      if (attempt < MAX_RETRIES) {
+        await new Promise(r => setTimeout(r, 1000 * attempt));
       }
     }
 

--- a/src/worker/feedback.ts
+++ b/src/worker/feedback.ts
@@ -1,6 +1,7 @@
-// Admin feedback view (#213). Renders submissions from D1 as a simple HTML table.
-// Token-guarded by the caller (see GET /feedback in index.ts). All user-controlled
-// values are HTML-escaped here — message/category/userAgent are attacker-influenced.
+// Admin feedback view (#213). Renders submissions from D1 as a mobile-first card
+// list. Access-gated by the caller (see GET /feedback in index.ts). All
+// user-controlled values are HTML-escaped — message/category/userAgent etc. are
+// attacker-influenced.
 
 export interface FeedbackRow {
   id: number;
@@ -36,51 +37,70 @@ function esc(v: unknown): string {
     .replaceAll('"', "&quot;");
 }
 
-// Collapsible cell for the raw localStorage debug blobs — kept out of the way but
-// available for reproducing a report.
+// Sample cards shown ONLY when the database returns no rows, so the layout can be
+// previewed locally without seeding. Clearly flagged as fake by the banner.
+const SAMPLE: FeedbackRow[] = [
+  { id: 5, created_at: "2026-04-30 09:21:24", category: "general", message: "Great game! Would be useful to have ‘undo’ and ‘restart’ buttons. Is there a reason the number can’t start with 0?", puzzle_number: "#54", puzzle_date: "2026-04-30", device: "iPhone", browser: "Safari 26.4", user_agent: "Mozilla/5.0 (iPhone …) Version/26.4 Mobile/15E148 Safari/604.1", history: null, prefs: null, active: null, tz_offset: 60, local_today: "2026-04-30", screen: "390x844", host: "clumeral.com" },
+  { id: 4, created_at: "2026-04-22 13:46:22", category: "praise", message: "Absolutely love this puzzle game! I've shared it with work colleagues and friends.", puzzle_number: "#46", puzzle_date: "2026-04-22", device: "Desktop", browser: "Edge 147.0.0.0", user_agent: null, history: null, prefs: null, active: null, tz_offset: null, local_today: null, screen: null, host: "clumeral.com" },
+  { id: 3, created_at: "2026-04-17 07:42:05", category: "suggestion", message: "It would be good to see your winning streak.", puzzle_number: "#41", puzzle_date: "2026-04-17", device: "Android Phone", browser: "Chrome 147.0.0.0", user_agent: null, history: null, prefs: null, active: null, tz_offset: null, local_today: null, screen: null, host: "clumeral.com" },
+  { id: 2, created_at: "2026-04-09 11:32:18", category: "bug", message: "Couldn't select 0 as the first number once I'd deselected it accidentally.", puzzle_number: "#33", puzzle_date: "2026-04-09", device: "Android Phone", browser: "Chrome 146.0.0.0", user_agent: "Mozilla/5.0 (Linux; Android 10; K) … Chrome/146.0.0.0 Mobile Safari/537.36", history: '[{"date":"2026-04-09","tries":2,"answer":800}]', prefs: '{"theme":"dark"}', active: null, tz_offset: 0, local_today: "2026-04-09", screen: "412x915", host: "clumeral.com" },
+  { id: 1, created_at: "2026-06-08 21:10:00", category: "general", message: "testing the form on the preview build", puzzle_number: "#93", puzzle_date: "2026-06-08", device: "Desktop", browser: "Firefox 150.0.2", user_agent: "Mozilla/5.0 (Windows NT 10.0 …) Firefox/150.0.2", history: null, prefs: null, active: null, tz_offset: 0, local_today: "2026-06-08", screen: "1280x720", host: "new-design-clumeral-game.jevawin.workers.dev" },
+];
+
+function source(host: string | null): string {
+  if (isTest(host)) return `<span class="badge test" title="${esc(host)}">test</span>`;
+  return `<span class="badge live">live</span>`;
+}
+
+// Raw localStorage / diagnostic blobs, tucked behind an expander.
 function debug(row: FeedbackRow): string {
-  const parts = [
-    ["history", row.history],
-    ["prefs", row.prefs],
-    ["active", row.active],
+  const parts = ([
+    ["host", row.host],
     ["userAgent", row.user_agent],
     ["screen", row.screen],
     ["tzOffset", row.tz_offset],
     ["localToday", row.local_today],
-  ].filter(([, v]) => v !== null && v !== "");
-  if (!parts.length) return "<span class=\"muted\">—</span>";
-  const body = parts.map(([k, v]) => `<div><b>${esc(k)}:</b> ${esc(v)}</div>`).join("");
-  return `<details><summary>debug</summary><div class="dbg">${body}</div></details>`;
+    ["history", row.history],
+    ["prefs", row.prefs],
+    ["active", row.active],
+  ] as [string, unknown][]).filter(([, v]) => v !== null && v !== "");
+  if (!parts.length) return "";
+  const body = parts.map(([k, v]) => `<div><b>${esc(k)}</b><span>${esc(v)}</span></div>`).join("");
+  return `<details class="dbg"><summary>Diagnostics</summary><div class="dbg-body">${body}</div></details>`;
 }
 
-function source(host: string | null): string {
-  if (isTest(host)) return `<span class="test" title="${esc(host)}">test</span>`;
-  return `<span class="muted">live</span>`;
+function card(r: FeedbackRow): string {
+  const meta = [r.puzzle_number, r.puzzle_date, r.device, r.browser]
+    .filter((v) => v !== null && v !== "")
+    .map((v) => `<span>${esc(v)}</span>`)
+    .join("");
+  return `<article class="card${isTest(r.host) ? " is-test" : ""}">
+    <div class="row">
+      <span class="cat cat-${esc(r.category)}">${esc(r.category)}</span>
+      ${source(r.host)}
+      <time>${esc(r.created_at)}</time>
+    </div>
+    <p class="msg">${esc(r.message)}</p>
+    <div class="meta">${meta}</div>
+    ${debug(r)}
+  </article>`;
 }
 
-export function renderFeedbackTable(rows: FeedbackRow[], hostname: string, showAll: boolean): string {
-  const tbody = rows.length
-    ? rows
-        .map(
-          (r) => `<tr class="${isTest(r.host) ? "is-test" : ""}">
-        <td class="num">${esc(r.id)}</td>
-        <td class="nowrap">${esc(r.created_at)}</td>
-        <td>${source(r.host)}</td>
-        <td><span class="cat cat-${esc(r.category)}">${esc(r.category)}</span></td>
-        <td class="msg">${esc(r.message)}</td>
-        <td class="nowrap">${esc(r.puzzle_number)}</td>
-        <td class="nowrap">${esc(r.puzzle_date)}</td>
-        <td>${esc(r.device)}</td>
-        <td>${esc(r.browser)}</td>
-        <td>${debug(r)}</td>
-      </tr>`,
-        )
-        .join("")
-    : `<tr><td colspan="10" class="muted center">No feedback yet.</td></tr>`;
+export function renderFeedbackPage(rows: FeedbackRow[], hostname: string, showAll: boolean): string {
+  const fake = rows.length === 0;
+  const list = fake ? SAMPLE : rows;
+
+  const banner = fake
+    ? `<div class="banner" role="alert">⚠ No feedback in this database yet — showing <b>sample data</b> so you can preview the layout. These are not real submissions.</div>`
+    : "";
 
   const toggle = showAll
-    ? `all sources · <a href="/feedback">show clumeral.com only</a>`
-    : `clumeral.com only · <a href="/feedback?all=1">show all (incl. test)</a>`;
+    ? `<a class="toggle" href="/feedback">Show clumeral.com only</a>`
+    : `<a class="toggle" href="/feedback?all=1">Show all (incl. test)</a>`;
+
+  const countLabel = fake
+    ? "sample data"
+    : `${list.length} ${showAll ? "submission" + (list.length === 1 ? "" : "s") + " · all sources" : "submission" + (list.length === 1 ? "" : "s")}`;
 
   return `<!doctype html>
 <html lang="en">
@@ -90,43 +110,57 @@ export function renderFeedbackTable(rows: FeedbackRow[], hostname: string, showA
 <meta name="robots" content="noindex, nofollow">
 <title>Feedback · ${esc(hostname)}</title>
 <style>
-  :root { color-scheme: light dark; --acc: light-dark(#2563eb, #60a5fa); --line: light-dark(#e5e7eb, #374151); --muted: light-dark(#6b7280, #9ca3af); }
+  :root {
+    color-scheme: light dark;
+    --acc: light-dark(#2563eb, #60a5fa);
+    --line: light-dark(#e5e7eb, #2b3240);
+    --card: light-dark(#ffffff, #161b22);
+    --muted: light-dark(#6b7280, #9aa4b2);
+    --warn-fg: light-dark(#92400e, #fbbf24);
+    --warn-bd: #f59e0b;
+    --warn-bg: light-dark(#fffbeb, #2a230f);
+  }
   * { box-sizing: border-box; }
-  body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 1.5rem; line-height: 1.4; }
-  h1 { font-size: 1.25rem; margin: 0 0 0.25rem; }
-  .sub { color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem; }
-  table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
-  th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--line); vertical-align: top; }
-  th { position: sticky; top: 0; background: Canvas; font-weight: 600; white-space: nowrap; }
-  .num { color: var(--muted); }
-  .nowrap { white-space: nowrap; }
-  .center { text-align: center; }
-  .muted { color: var(--muted); }
-  .msg { max-width: 38ch; white-space: pre-wrap; word-break: break-word; }
-  .cat { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 999px; border: 1px solid var(--line); font-size: 0.75rem; }
+  body { font-family: system-ui, -apple-system, sans-serif; margin: 0; background: Canvas; line-height: 1.45; -webkit-text-size-adjust: 100%; }
+  .wrap { max-width: 680px; margin: 0 auto; padding: 1rem 1rem 3rem; }
+  header.top { position: sticky; top: 0; background: Canvas; padding: 0.75rem 0; border-bottom: 1px solid var(--line); z-index: 1; }
+  h1 { font-size: 1.15rem; margin: 0; }
+  .sub { color: var(--muted); font-size: 0.82rem; margin: 0.2rem 0 0; display: flex; flex-wrap: wrap; gap: 0.5rem 0.75rem; align-items: center; }
+  .toggle { margin-left: auto; color: var(--acc); text-decoration: none; padding: 0.4rem 0.6rem; border: 1px solid var(--line); border-radius: 8px; min-height: 36px; display: inline-flex; align-items: center; }
+  .banner { margin: 0.9rem 0 0; padding: 0.7rem 0.85rem; border: 1px solid var(--warn-bd); background: var(--warn-bg); color: var(--warn-fg); border-radius: 10px; font-size: 0.85rem; }
+  .list { margin-top: 0.9rem; display: flex; flex-direction: column; gap: 0.75rem; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 0.85rem 0.9rem; }
+  .card.is-test { opacity: 0.72; }
+  .row { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+  .row time { margin-left: auto; color: var(--muted); font-size: 0.75rem; white-space: nowrap; }
+  .cat { display: inline-block; padding: 0.12rem 0.5rem; border-radius: 999px; border: 1px solid var(--line); font-size: 0.72rem; text-transform: capitalize; }
   .cat-bug { color: #dc2626; border-color: #dc2626; }
   .cat-praise { color: #16a34a; border-color: #16a34a; }
   .cat-suggestion { color: var(--acc); border-color: var(--acc); }
-  .test { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 999px; font-size: 0.72rem; color: #b45309; border: 1px solid #f59e0b; background: light-dark(#fffbeb, transparent); }
-  tr.is-test { opacity: 0.7; }
-  details summary { cursor: pointer; color: var(--acc); }
-  .dbg { margin-top: 0.4rem; font-family: ui-monospace, monospace; font-size: 0.72rem; max-width: 40ch; word-break: break-all; }
-  .dbg div { margin: 0.15rem 0; }
-  a { color: var(--acc); }
+  .badge { display: inline-block; padding: 0.12rem 0.5rem; border-radius: 999px; font-size: 0.7rem; }
+  .badge.live { color: var(--muted); border: 1px solid var(--line); }
+  .badge.test { color: var(--warn-fg); border: 1px solid var(--warn-bd); }
+  .msg { margin: 0.55rem 0 0; white-space: pre-wrap; word-break: break-word; font-size: 0.95rem; }
+  .meta { margin-top: 0.55rem; display: flex; flex-wrap: wrap; gap: 0.25rem 0.5rem; color: var(--muted); font-size: 0.76rem; }
+  .meta span:not(:last-child)::after { content: " ·"; margin-left: 0.5rem; }
+  .dbg { margin-top: 0.55rem; }
+  .dbg summary { cursor: pointer; color: var(--acc); font-size: 0.8rem; min-height: 32px; display: inline-flex; align-items: center; }
+  .dbg-body { margin-top: 0.4rem; font-family: ui-monospace, monospace; font-size: 0.72rem; }
+  .dbg-body div { display: flex; gap: 0.5rem; padding: 0.2rem 0; border-top: 1px solid var(--line); }
+  .dbg-body b { color: var(--muted); flex: 0 0 5.5rem; }
+  .dbg-body span { word-break: break-all; min-width: 0; }
+  .empty { color: var(--muted); text-align: center; padding: 2rem 0; }
 </style>
 </head>
 <body>
-  <h1>Feedback</h1>
-  <p class="sub">${esc(hostname)} · ${rows.length} submission${rows.length === 1 ? "" : "s"} · ${toggle}</p>
-  <table>
-    <thead>
-      <tr>
-        <th>#</th><th>Received</th><th>Source</th><th>Type</th><th>Message</th>
-        <th>Puzzle</th><th>Date</th><th>Device</th><th>Browser</th><th>Debug</th>
-      </tr>
-    </thead>
-    <tbody>${tbody}</tbody>
-  </table>
+  <div class="wrap">
+    <header class="top">
+      <h1>Feedback</h1>
+      <p class="sub"><span>${esc(hostname)}</span><span>${countLabel}</span>${toggle}</p>
+    </header>
+    ${banner}
+    <div class="list">${list.map(card).join("")}</div>
+  </div>
 </body>
 </html>`;
 }

--- a/src/worker/feedback.ts
+++ b/src/worker/feedback.ts
@@ -1,0 +1,111 @@
+// Admin feedback view (#213). Renders submissions from D1 as a simple HTML table.
+// Token-guarded by the caller (see GET /feedback in index.ts). All user-controlled
+// values are HTML-escaped here — message/category/userAgent are attacker-influenced.
+
+export interface FeedbackRow {
+  id: number;
+  created_at: string;
+  category: string | null;
+  message: string | null;
+  puzzle_number: string | null;
+  puzzle_date: string | null;
+  device: string | null;
+  browser: string | null;
+  user_agent: string | null;
+  history: string | null;
+  prefs: string | null;
+  active: string | null;
+  tz_offset: number | null;
+  local_today: string | null;
+  screen: string | null;
+}
+
+function esc(v: unknown): string {
+  return String(v ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+// Collapsible cell for the raw localStorage debug blobs — kept out of the way but
+// available for reproducing a report.
+function debug(row: FeedbackRow): string {
+  const parts = [
+    ["history", row.history],
+    ["prefs", row.prefs],
+    ["active", row.active],
+    ["userAgent", row.user_agent],
+    ["screen", row.screen],
+    ["tzOffset", row.tz_offset],
+    ["localToday", row.local_today],
+  ].filter(([, v]) => v !== null && v !== "");
+  if (!parts.length) return "<span class=\"muted\">—</span>";
+  const body = parts.map(([k, v]) => `<div><b>${esc(k)}:</b> ${esc(v)}</div>`).join("");
+  return `<details><summary>debug</summary><div class="dbg">${body}</div></details>`;
+}
+
+export function renderFeedbackTable(rows: FeedbackRow[], hostname: string): string {
+  const tbody = rows.length
+    ? rows
+        .map(
+          (r) => `<tr>
+        <td class="num">${esc(r.id)}</td>
+        <td class="nowrap">${esc(r.created_at)}</td>
+        <td><span class="cat cat-${esc(r.category)}">${esc(r.category)}</span></td>
+        <td class="msg">${esc(r.message)}</td>
+        <td class="nowrap">${esc(r.puzzle_number)}</td>
+        <td class="nowrap">${esc(r.puzzle_date)}</td>
+        <td>${esc(r.device)}</td>
+        <td>${esc(r.browser)}</td>
+        <td>${debug(r)}</td>
+      </tr>`,
+        )
+        .join("")
+    : `<tr><td colspan="9" class="muted center">No feedback yet.</td></tr>`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Feedback · ${esc(hostname)}</title>
+<style>
+  :root { color-scheme: light dark; --acc: light-dark(#2563eb, #60a5fa); --line: light-dark(#e5e7eb, #374151); --muted: light-dark(#6b7280, #9ca3af); }
+  * { box-sizing: border-box; }
+  body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 1.5rem; line-height: 1.4; }
+  h1 { font-size: 1.25rem; margin: 0 0 0.25rem; }
+  .sub { color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
+  th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { position: sticky; top: 0; background: Canvas; font-weight: 600; white-space: nowrap; }
+  .num { color: var(--muted); }
+  .nowrap { white-space: nowrap; }
+  .center { text-align: center; }
+  .muted { color: var(--muted); }
+  .msg { max-width: 38ch; white-space: pre-wrap; word-break: break-word; }
+  .cat { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 999px; border: 1px solid var(--line); font-size: 0.75rem; }
+  .cat-bug { color: #dc2626; border-color: #dc2626; }
+  .cat-praise { color: #16a34a; border-color: #16a34a; }
+  .cat-suggestion { color: var(--acc); border-color: var(--acc); }
+  details summary { cursor: pointer; color: var(--acc); }
+  .dbg { margin-top: 0.4rem; font-family: ui-monospace, monospace; font-size: 0.72rem; max-width: 40ch; word-break: break-all; }
+  .dbg div { margin: 0.15rem 0; }
+</style>
+</head>
+<body>
+  <h1>Feedback</h1>
+  <p class="sub">${esc(hostname)} · ${rows.length} most recent submission${rows.length === 1 ? "" : "s"}</p>
+  <table>
+    <thead>
+      <tr>
+        <th>#</th><th>Received</th><th>Type</th><th>Message</th>
+        <th>Puzzle</th><th>Date</th><th>Device</th><th>Browser</th><th>Debug</th>
+      </tr>
+    </thead>
+    <tbody>${tbody}</tbody>
+  </table>
+</body>
+</html>`;
+}

--- a/src/worker/feedback.ts
+++ b/src/worker/feedback.ts
@@ -18,6 +18,14 @@ export interface FeedbackRow {
   tz_offset: number | null;
   local_today: string | null;
   screen: string | null;
+  host: string | null;
+}
+
+// Real feedback comes from the production host; everything else (preview
+// deploys, localhost) is test traffic.
+const REAL_HOST = "clumeral.com";
+function isTest(host: string | null): boolean {
+  return host !== null && host !== REAL_HOST;
 }
 
 function esc(v: unknown): string {
@@ -45,13 +53,19 @@ function debug(row: FeedbackRow): string {
   return `<details><summary>debug</summary><div class="dbg">${body}</div></details>`;
 }
 
-export function renderFeedbackTable(rows: FeedbackRow[], hostname: string): string {
+function source(host: string | null): string {
+  if (isTest(host)) return `<span class="test" title="${esc(host)}">test</span>`;
+  return `<span class="muted">live</span>`;
+}
+
+export function renderFeedbackTable(rows: FeedbackRow[], hostname: string, showAll: boolean): string {
   const tbody = rows.length
     ? rows
         .map(
-          (r) => `<tr>
+          (r) => `<tr class="${isTest(r.host) ? "is-test" : ""}">
         <td class="num">${esc(r.id)}</td>
         <td class="nowrap">${esc(r.created_at)}</td>
+        <td>${source(r.host)}</td>
         <td><span class="cat cat-${esc(r.category)}">${esc(r.category)}</span></td>
         <td class="msg">${esc(r.message)}</td>
         <td class="nowrap">${esc(r.puzzle_number)}</td>
@@ -62,7 +76,11 @@ export function renderFeedbackTable(rows: FeedbackRow[], hostname: string): stri
       </tr>`,
         )
         .join("")
-    : `<tr><td colspan="9" class="muted center">No feedback yet.</td></tr>`;
+    : `<tr><td colspan="10" class="muted center">No feedback yet.</td></tr>`;
+
+  const toggle = showAll
+    ? `all sources · <a href="/feedback">show clumeral.com only</a>`
+    : `clumeral.com only · <a href="/feedback?all=1">show all (incl. test)</a>`;
 
   return `<!doctype html>
 <html lang="en">
@@ -89,18 +107,21 @@ export function renderFeedbackTable(rows: FeedbackRow[], hostname: string): stri
   .cat-bug { color: #dc2626; border-color: #dc2626; }
   .cat-praise { color: #16a34a; border-color: #16a34a; }
   .cat-suggestion { color: var(--acc); border-color: var(--acc); }
+  .test { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 999px; font-size: 0.72rem; color: #b45309; border: 1px solid #f59e0b; background: light-dark(#fffbeb, transparent); }
+  tr.is-test { opacity: 0.7; }
   details summary { cursor: pointer; color: var(--acc); }
   .dbg { margin-top: 0.4rem; font-family: ui-monospace, monospace; font-size: 0.72rem; max-width: 40ch; word-break: break-all; }
   .dbg div { margin: 0.15rem 0; }
+  a { color: var(--acc); }
 </style>
 </head>
 <body>
   <h1>Feedback</h1>
-  <p class="sub">${esc(hostname)} · ${rows.length} most recent submission${rows.length === 1 ? "" : "s"}</p>
+  <p class="sub">${esc(hostname)} · ${rows.length} submission${rows.length === 1 ? "" : "s"} · ${toggle}</p>
   <table>
     <thead>
       <tr>
-        <th>#</th><th>Received</th><th>Type</th><th>Message</th>
+        <th>#</th><th>Received</th><th>Source</th><th>Type</th><th>Message</th>
         <th>Puzzle</th><th>Date</th><th>Device</th><th>Browser</th><th>Debug</th>
       </tr>
     </thead>

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -154,7 +154,20 @@ function str(v: unknown, max: number): string | null {
   return t.length > max ? t.slice(0, max) : t;
 }
 
+// Known feedback categories — anything else is bucketed as 'other' so the column
+// stays a bounded, predictable set (the client only sends these four).
+const FEEDBACK_CATEGORIES = new Set(['general', 'bug', 'praise', 'suggestion']);
+
+// Reject oversized bodies before buffering. The per-field caps below sum to ~30KB;
+// 64KB leaves headroom for JSON overhead while bounding memory per request.
+const MAX_FEEDBACK_BODY = 64 * 1024;
+
 async function handleFeedbackSubmit(request: Request, env: Env): Promise<Response> {
+  const declaredLen = Number(request.headers.get('content-length') || 0);
+  if (declaredLen > MAX_FEEDBACK_BODY) {
+    return json({ error: 'Payload too large' }, 413);
+  }
+
   let body: FeedbackBody;
   try {
     body = await request.json() as FeedbackBody;
@@ -162,7 +175,8 @@ async function handleFeedbackSubmit(request: Request, env: Env): Promise<Respons
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const category = str(body.category, 32) ?? 'general';
+  const rawCategory = str(body.category, 32) ?? 'general';
+  const category = FEEDBACK_CATEGORIES.has(rawCategory) ? rawCategory : 'other';
   const message = str(body.message, 2000);
   if (!message) return json({ error: 'Message required' }, 400);
 
@@ -192,8 +206,9 @@ async function handleFeedbackSubmit(request: Request, env: Env): Promise<Respons
       str(body.screen, 32),
     ).run();
   } catch (err: unknown) {
-    const e = err instanceof Error ? err : new Error(String(err));
-    return json({ error: `Storage failed: ${e.message}` }, 500);
+    // Log the real cause (visible via `wrangler tail`); never leak schema/SQL to the client.
+    console.error('Feedback insert failed:', err instanceof Error ? err.message : String(err));
+    return json({ error: 'Could not save feedback' }, 500);
   }
 
   return json({ ok: true }, 200);
@@ -207,7 +222,9 @@ async function handleFeedbackList(env: Env, url: URL): Promise<Response> {
   if (url.searchParams.get('token') !== env.FEEDBACK_ADMIN_TOKEN) {
     return json({ error: 'Unauthorized' }, 401);
   }
-  const limit = Math.min(Number(url.searchParams.get('limit') || 100), 500) || 100;
+  // Clamp to [1, 500]. Guard the negative case explicitly — SQLite treats a
+  // negative LIMIT as "no limit", which would defeat the cap on a large table.
+  const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 100, 500));
   try {
     const { results } = await env.FEEDBACK_DB.prepare(
       `SELECT id, created_at, category, message, puzzle_number, puzzle_date,
@@ -218,8 +235,8 @@ async function handleFeedbackList(env: Env, url: URL): Promise<Response> {
     ).bind(limit).all();
     return json({ count: results.length, feedback: results }, 200, { 'Cache-Control': 'no-store' });
   } catch (err: unknown) {
-    const e = err instanceof Error ? err : new Error(String(err));
-    return json({ error: `Query failed: ${e.message}` }, 500);
+    console.error('Feedback query failed:', err instanceof Error ? err.message : String(err));
+    return json({ error: 'Could not load feedback' }, 500);
   }
 }
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,6 +6,7 @@ import { signToken, verifyToken } from './crypto.ts';
 import { isFuturePuzzleDate } from './date-guard.ts';
 import { getStats, renderDashboard } from './stats.ts';
 import { renderArchivePage } from './puzzles.ts';
+import { renderFeedbackTable, type FeedbackRow } from './feedback.ts';
 
 interface Env {
   ASSETS: { fetch: (req: Request) => Promise<Response> };
@@ -308,6 +309,32 @@ export default {
 
     if (request.method === 'GET' && url.pathname === '/api/feedback') {
       return handleFeedbackList(env, url);
+    }
+
+    // GET /feedback — admin HTML table. Same token gate as the JSON list.
+    if (request.method === 'GET' && url.pathname === '/feedback') {
+      if (!env.FEEDBACK_ADMIN_TOKEN) {
+        return new Response('Admin token not configured. Set FEEDBACK_ADMIN_TOKEN as a Worker secret.', {
+          status: 503, headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+      if (url.searchParams.get('token') !== env.FEEDBACK_ADMIN_TOKEN) {
+        return new Response('Unauthorized', { status: 401, headers: { 'Content-Type': 'text/plain' } });
+      }
+      const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 200, 500));
+      try {
+        const { results } = await env.FEEDBACK_DB.prepare(
+          `SELECT id, created_at, category, message, puzzle_number, puzzle_date, device,
+                  browser, user_agent, history, prefs, active, tz_offset, local_today, screen
+             FROM feedback ORDER BY id DESC LIMIT ?`,
+        ).bind(limit).all<FeedbackRow>();
+        return new Response(renderFeedbackTable(results, url.hostname), {
+          headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
+        });
+      } catch (err: unknown) {
+        console.error('Feedback page query failed:', err instanceof Error ? err.message : String(err));
+        return new Response('Could not load feedback', { status: 500, headers: { 'Content-Type': 'text/plain' } });
+      }
     }
 
     // ── Analytics ──

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,7 +6,7 @@ import { signToken, verifyToken } from './crypto.ts';
 import { isFuturePuzzleDate } from './date-guard.ts';
 import { getStats, renderDashboard } from './stats.ts';
 import { renderArchivePage } from './puzzles.ts';
-import { renderFeedbackTable, type FeedbackRow } from './feedback.ts';
+import { renderFeedbackPage, type FeedbackRow } from './feedback.ts';
 
 interface Env {
   ASSETS: { fetch: (req: Request) => Promise<Response> };
@@ -304,7 +304,7 @@ export default {
                 ORDER BY id DESC LIMIT ?`,
             ).bind(limit);
         const { results } = await stmt.all<FeedbackRow>();
-        return new Response(renderFeedbackTable(results, url.hostname, showAll), {
+        return new Response(renderFeedbackPage(results, url.hostname, showAll), {
           headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
         });
       } catch (err: unknown) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -183,12 +183,16 @@ async function handleFeedbackSubmit(request: Request, env: Env): Promise<Respons
     ? Math.trunc(body.tzOffset)
     : null;
 
+  // Server-set: which host received this submission. clumeral.com = real;
+  // preview/localhost = test. Never trust the client for this.
+  const host = new URL(request.url).hostname;
+
   try {
     await env.FEEDBACK_DB.prepare(
       `INSERT INTO feedback
          (category, message, puzzle_number, puzzle_date, device, browser,
-          user_agent, history, prefs, active, tz_offset, local_today, screen)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          user_agent, history, prefs, active, tz_offset, local_today, screen, host)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).bind(
       category,
       message,
@@ -203,6 +207,7 @@ async function handleFeedbackSubmit(request: Request, env: Env): Promise<Respons
       tzOffset,
       str(body.localToday, 16),
       str(body.screen, 32),
+      host,
     ).run();
   } catch (err: unknown) {
     // Log the real cause (visible via `wrangler tail`); never leak schema/SQL to the client.
@@ -285,13 +290,21 @@ export default {
     // players can still submit.
     if (request.method === 'GET' && url.pathname === '/feedback') {
       const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 200, 500));
+      // Default to real (clumeral.com) feedback; ?all=1 includes preview/test rows.
+      // Legacy rows were backfilled to clumeral.com, so the NULL case = real too.
+      const showAll = url.searchParams.get('all') === '1';
+      const cols = `id, created_at, category, message, puzzle_number, puzzle_date, device,
+                    browser, user_agent, history, prefs, active, tz_offset, local_today, screen, host`;
       try {
-        const { results } = await env.FEEDBACK_DB.prepare(
-          `SELECT id, created_at, category, message, puzzle_number, puzzle_date, device,
-                  browser, user_agent, history, prefs, active, tz_offset, local_today, screen
-             FROM feedback ORDER BY id DESC LIMIT ?`,
-        ).bind(limit).all<FeedbackRow>();
-        return new Response(renderFeedbackTable(results, url.hostname), {
+        const stmt = showAll
+          ? env.FEEDBACK_DB.prepare(`SELECT ${cols} FROM feedback ORDER BY id DESC LIMIT ?`).bind(limit)
+          : env.FEEDBACK_DB.prepare(
+              `SELECT ${cols} FROM feedback
+                WHERE host = 'clumeral.com' OR host IS NULL
+                ORDER BY id DESC LIMIT ?`,
+            ).bind(limit);
+        const { results } = await stmt.all<FeedbackRow>();
+        return new Response(renderFeedbackTable(results, url.hostname, showAll), {
           headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
         });
       } catch (err: unknown) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -16,8 +16,6 @@ interface Env {
   HMAC_SECRET: string;
   CF_ACCOUNT_ID: string;
   CF_API_TOKEN: string;
-  // Guards the read-only admin feedback view. Unset → admin view returns 503.
-  FEEDBACK_ADMIN_TOKEN: string;
 }
 
 interface StoredPuzzle {
@@ -215,32 +213,6 @@ async function handleFeedbackSubmit(request: Request, env: Env): Promise<Respons
   return json({ ok: true }, 200);
 }
 
-// Read-only admin view of submissions. Token-guarded like the /stats dashboard.
-async function handleFeedbackList(env: Env, url: URL): Promise<Response> {
-  if (!env.FEEDBACK_ADMIN_TOKEN) {
-    return json({ error: 'Admin token not configured' }, 503);
-  }
-  if (url.searchParams.get('token') !== env.FEEDBACK_ADMIN_TOKEN) {
-    return json({ error: 'Unauthorized' }, 401);
-  }
-  // Clamp to [1, 500]. Guard the negative case explicitly — SQLite treats a
-  // negative LIMIT as "no limit", which would defeat the cap on a large table.
-  const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 100, 500));
-  try {
-    const { results } = await env.FEEDBACK_DB.prepare(
-      `SELECT id, created_at, category, message, puzzle_number, puzzle_date,
-              device, browser, user_agent, tz_offset, local_today, screen
-         FROM feedback
-        ORDER BY id DESC
-        LIMIT ?`,
-    ).bind(limit).all();
-    return json({ count: results.length, feedback: results }, 200, { 'Cache-Control': 'no-store' });
-  } catch (err: unknown) {
-    console.error('Feedback query failed:', err instanceof Error ? err.message : String(err));
-    return json({ error: 'Could not load feedback' }, 500);
-  }
-}
-
 // ─── Main fetch handler ──────────────────────────────────────────────────────
 
 export default {
@@ -307,20 +279,11 @@ export default {
       return handleFeedbackSubmit(request, env);
     }
 
-    if (request.method === 'GET' && url.pathname === '/api/feedback') {
-      return handleFeedbackList(env, url);
-    }
-
-    // GET /feedback — admin HTML table. Same token gate as the JSON list.
+    // GET /feedback — admin HTML table. Access control is enforced at the edge by
+    // Cloudflare Access (Zero Trust app on this path), not in code — like an
+    // unlinked dashboard, but private. POST /api/feedback above stays public so
+    // players can still submit.
     if (request.method === 'GET' && url.pathname === '/feedback') {
-      if (!env.FEEDBACK_ADMIN_TOKEN) {
-        return new Response('Admin token not configured. Set FEEDBACK_ADMIN_TOKEN as a Worker secret.', {
-          status: 503, headers: { 'Content-Type': 'text/plain' },
-        });
-      }
-      if (url.searchParams.get('token') !== env.FEEDBACK_ADMIN_TOKEN) {
-        return new Response('Unauthorized', { status: 401, headers: { 'Content-Type': 'text/plain' } });
-      }
       const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 200, 500));
       try {
         const { results } = await env.FEEDBACK_DB.prepare(

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -11,9 +11,12 @@ interface Env {
   ASSETS: { fetch: (req: Request) => Promise<Response> };
   ANALYTICS: AnalyticsEngineDataset;
   PUZZLES: KVNamespace;
+  FEEDBACK_DB: D1Database;
   HMAC_SECRET: string;
   CF_ACCOUNT_ID: string;
   CF_API_TOKEN: string;
+  // Guards the read-only admin feedback view. Unset → admin view returns 503.
+  FEEDBACK_ADMIN_TOKEN: string;
 }
 
 interface StoredPuzzle {
@@ -125,6 +128,101 @@ async function handleGuess(request: Request, env: Env): Promise<Response> {
   return json({ error: 'Provide either date or token' }, 400);
 }
 
+// ─── Feedback (D1) ───────────────────────────────────────────────────────────
+
+interface FeedbackBody {
+  category?: string;
+  message?: string;
+  puzzleNumber?: string;
+  date?: string;
+  device?: string;
+  browser?: string;
+  userAgent?: string;
+  history?: string;
+  prefs?: string;
+  active?: string;
+  tzOffset?: number;
+  localToday?: string;
+  screen?: string;
+}
+
+// Coerce any client value to a trimmed, length-capped string (or null when empty).
+function str(v: unknown, max: number): string | null {
+  if (typeof v !== 'string') return null;
+  const t = v.trim();
+  if (!t) return null;
+  return t.length > max ? t.slice(0, max) : t;
+}
+
+async function handleFeedbackSubmit(request: Request, env: Env): Promise<Response> {
+  let body: FeedbackBody;
+  try {
+    body = await request.json() as FeedbackBody;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const category = str(body.category, 32) ?? 'general';
+  const message = str(body.message, 2000);
+  if (!message) return json({ error: 'Message required' }, 400);
+
+  const tzOffset = typeof body.tzOffset === 'number' && Number.isFinite(body.tzOffset)
+    ? Math.trunc(body.tzOffset)
+    : null;
+
+  try {
+    await env.FEEDBACK_DB.prepare(
+      `INSERT INTO feedback
+         (category, message, puzzle_number, puzzle_date, device, browser,
+          user_agent, history, prefs, active, tz_offset, local_today, screen)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      category,
+      message,
+      str(body.puzzleNumber, 16),
+      str(body.date, 16),
+      str(body.device, 64),
+      str(body.browser, 64),
+      str(body.userAgent, 512),
+      str(body.history, 8192),
+      str(body.prefs, 4096),
+      str(body.active, 4096),
+      tzOffset,
+      str(body.localToday, 16),
+      str(body.screen, 32),
+    ).run();
+  } catch (err: unknown) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    return json({ error: `Storage failed: ${e.message}` }, 500);
+  }
+
+  return json({ ok: true }, 200);
+}
+
+// Read-only admin view of submissions. Token-guarded like the /stats dashboard.
+async function handleFeedbackList(env: Env, url: URL): Promise<Response> {
+  if (!env.FEEDBACK_ADMIN_TOKEN) {
+    return json({ error: 'Admin token not configured' }, 503);
+  }
+  if (url.searchParams.get('token') !== env.FEEDBACK_ADMIN_TOKEN) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+  const limit = Math.min(Number(url.searchParams.get('limit') || 100), 500) || 100;
+  try {
+    const { results } = await env.FEEDBACK_DB.prepare(
+      `SELECT id, created_at, category, message, puzzle_number, puzzle_date,
+              device, browser, user_agent, tz_offset, local_today, screen
+         FROM feedback
+        ORDER BY id DESC
+        LIMIT ?`,
+    ).bind(limit).all();
+    return json({ count: results.length, feedback: results }, 200, { 'Cache-Control': 'no-store' });
+  } catch (err: unknown) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    return json({ error: `Query failed: ${e.message}` }, 500);
+  }
+}
+
 // ─── Main fetch handler ──────────────────────────────────────────────────────
 
 export default {
@@ -183,6 +281,16 @@ export default {
       const today = todayUTC();
       const puzzle = await getDailyPuzzle(env, today);
       return json({ answer: puzzle.answer });
+    }
+
+    // ── Feedback ──
+
+    if (request.method === 'POST' && url.pathname === '/api/feedback') {
+      return handleFeedbackSubmit(request, env);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/api/feedback') {
+      return handleFeedbackList(env, url);
     }
 
     // ── Analytics ──

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,39 +1,47 @@
 {
-  "name": "clumeral-game",
-  "compatibility_date": "2026-03-09",
-  "main": "./src/worker/index.ts",
-  "assets": {
-    "binding": "ASSETS",
-    "run_worker_first": [
-      "/", "/index.html",
-      "/welcome", "/play", "/solved",
-      "/archive", "/archive/*",
-      "/random",
-      "/puzzles", "/puzzles/*",
-      "/api/*", "/stats",
-      "/sw.js"
-    ]
-  },
-  "analytics_engine_datasets": [
-    {
-      "binding": "ANALYTICS",
-      "dataset": "clumeral"
-    }
-  ],
-  "kv_namespaces": [
-    {
-      "binding": "PUZZLES",
-      "id": "d07cfc9a455943e3839967475925a468"
-    }
-  ],
-  "d1_databases": [
-    {
-      "binding": "FEEDBACK_DB",
-      "database_name": "clumeral-feedback",
-      "database_id": "PLACEHOLDER_SET_AFTER_D1_CREATE"
-    }
-  ],
-  "triggers": {
-    "crons": ["0 0 * * *"]
-  }
+	"name": "clumeral-game",
+	"compatibility_date": "2026-03-09",
+	"main": "./src/worker/index.ts",
+	"assets": {
+		"binding": "ASSETS",
+		"run_worker_first": [
+			"/",
+			"/index.html",
+			"/welcome",
+			"/play",
+			"/solved",
+			"/archive",
+			"/archive/*",
+			"/random",
+			"/puzzles",
+			"/puzzles/*",
+			"/api/*",
+			"/stats",
+			"/sw.js"
+		]
+	},
+	"analytics_engine_datasets": [
+		{
+			"binding": "ANALYTICS",
+			"dataset": "clumeral"
+		}
+	],
+	"kv_namespaces": [
+		{
+			"binding": "PUZZLES",
+			"id": "d07cfc9a455943e3839967475925a468"
+		}
+	],
+	"d1_databases": [
+		{
+			"binding": "FEEDBACK_DB",
+			"database_name": "clumeral-feedback",
+			"database_id": "4ecc6c31-c26c-4652-a1ae-7d1746bd816d"
+		}
+	],
+	"triggers": {
+		"crons": [
+			"0 0 * * *"
+		]
+	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,13 @@
       "id": "d07cfc9a455943e3839967475925a468"
     }
   ],
+  "d1_databases": [
+    {
+      "binding": "FEEDBACK_DB",
+      "database_name": "clumeral-feedback",
+      "database_id": "PLACEHOLDER_SET_AFTER_D1_CREATE"
+    }
+  ],
   "triggers": {
     "crons": ["0 0 * * *"]
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,6 +17,7 @@
 			"/puzzles/*",
 			"/api/*",
 			"/stats",
+			"/feedback",
 			"/sw.js"
 		]
 	},


### PR DESCRIPTION
Closes #213.

## What
Move feedback off the external Google Apps Script endpoint onto a same-origin **Cloudflare D1**–backed Worker route, with a private admin dashboard at `/feedback` that separates real feedback from test traffic.

Chose D1 over Supabase: free-tier project cap, no external account, no key management (Worker binding), all inside infra we already deploy to.

## Changes
- **Schema** — `migrations/0001_create_feedback.sql`: `feedback` table (+ `created_at` index, `host` column). `0003_add_host_column.sql`: ALTER + backfill for the already-migrated remote D1.
- **Worker** (`src/worker/index.ts`):
  - `POST /api/feedback` — **public**. Validates, length-caps, allowlists `category`, rejects >64KB, records the request host (server-set), parameterized insert.
  - `GET /feedback` — admin HTML table (`src/worker/feedback.ts`), all values HTML-escaped, debug blobs in a collapsible cell. **Defaults to real (clumeral.com) feedback**; `?all=1` shows preview/local test rows with a `test` badge + Source column. **Gated by Cloudflare Access**, not an in-app token.
  - `FEEDBACK_DB` binding; `/feedback` in `run_worker_first`.
- **Client** (`src/modals.ts`) — same-origin POST; Google URL gone from the bundle; retry + toast preserved.
- **e2e** — real preview Worker against a local miniflare D1 (`e2e:db` drop+recreates the schema each run). No network stub.
- **Data** — 11 legacy submissions imported to remote D1 (test/garbage rows excluded); import SQL gitignored (real user content).

## Acceptance criteria
- [x] Feedback submits to D1; row appears — verified local + remote.
- [x] Google Apps Script URL removed from the client bundle.
- [x] Failure path still shows the existing toast.
- [x] e2e observes a same-origin feedback endpoint.
- [x] Admin view — private `/feedback`, real-vs-test separation.

## QA
Focused (agreed up front): feedback + smoke across the 5-engine matrix — green (webkit menu-animation flakes auto-pass on retry). `tsc` + build pass. `/feedback` manually verified: default filter, `?all=1` toggle, test badge, host capture, HTML escaping of `<script>`/`<img onerror>`.

## Review gates
- **DA review** (fresh-context subagent): High resolved; Mediums/Lows folded in.
- **Self-review**: line-level clean.

## ⚠️ Before merging onward / to main
1. **Remote `host` column** (the code writes it on every submit): `npx wrangler d1 execute clumeral-feedback --remote --file=migrations/0003_add_host_column.sql` — run once.
2. **Cloudflare Access** must cover `/feedback` on whatever host serves it (clumeral.com, and any preview domain you want to view it on) — there is no in-app auth.

Remote `0001` table + legacy import already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
