### PR TITLE
Fix /random solve crash + entry link + theme-aware shadows

### DIFF
--- a/docs/superpowers/plans/2026-06-28-pr1-random-and-shadow-fixes.md
+++ b/docs/superpowers/plans/2026-06-28-pr1-random-and-shadow-fixes.md
@@ -1,0 +1,413 @@
+# PR 1 — /random and shadow fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the two user-facing post-redesign bugs — `/random` throws "Something went wrong" on a correct answer, and digit-box shadows ignore the selected accent colour — and re-add the only `/random` entry link, each guarded by a Playwright regression test.
+
+**Architecture:** Three small, independent changes. (1) `/random` boots without `initRouter`, so the solve path's `replaceRoute('/solved')` calls `ctx()` which throws `router not initialized`; show the completion screen directly for random instead of routing. (2) Add a "Play another random puzzle" link to the random completion screen — the sole `/random` entry point. (3) Replace hardcoded shadow colours with theme tokens (`color-mix` off `--color-text` / `--color-accent`) so shadows follow the active accent and dark mode.
+
+**Tech Stack:** TypeScript, Vite, Tailwind CSS v4 (`@theme` tokens), Cloudflare Workers, Playwright e2e (`@playwright/test`). Local run: `npm run e2e:serve` (build + preview on :4173, seeds local D1). Tests: `npm run test:e2e`.
+
+---
+
+## Background (verified during planning)
+
+- Root cause of the submit crash: [src/router.ts:67-68](../../../src/router.ts#L67) — `ctx()` does `if (!deps) throw new Error('router not initialized')`. The `/random` boot path [src/app.ts:972-975](../../../src/app.ts#L972) calls `showScreen('game'); loadPuzzle();` and never calls `initRouter`, so `deps` stays null. A correct guess runs `handleGuess` → `replaceRoute('/solved')` → `navigate` → `ctx()` → throws → caught at [src/app.ts:741](../../../src/app.ts#L741) → `renderFeedback("error")`. Reproduced locally: correct answer on `/random` shows "Something went wrong — please try again." with completion heading already set to "Puzzle solved!".
+- Shadow bug: the active digit-box shadow [src/app.ts:351](../../../src/app.ts#L351) hardcodes `rgba(10,133,10,0.3)` = Lime `#0A850A`. Accent is applied as `--color-accent` ([src/colours.ts:32](../../../src/colours.ts#L32)); the four accents are Lime/Berry/Blue/Violet. On Berry/Blue/Violet the active shadow stays green. The SSR stats page ([src/worker/stats.ts](../../../src/worker/stats.ts)) uses a separate `light-dark()` palette and adapts correctly — **out of scope**.
+- Screen state machine toggles `aria-hidden` per `<section data-screen>` ([src/screens.ts:90](../../../src/screens.ts#L90)); `showScreen` is already imported in app.ts. e2e helper `expectActiveScreen` asserts on `aria-hidden`.
+
+## File structure
+
+- Modify `src/app.ts` — solve branch: route to completion screen for random without `replaceRoute`.
+- Modify `src/completion.ts` — render the "Play another random puzzle" link when `isRandom`.
+- Modify `src/tailwind.css` — add `--shadow-*` theme tokens; fix octo drop-shadow.
+- Modify `index.html`, `src/app.ts`, `src/welcome.ts` — swap hardcoded shadow classes for the tokens.
+- Create `e2e/specs/random.spec.ts` — random solve + entry-link regressions.
+- Create `e2e/specs/shadow-theme.spec.ts` — active-box shadow follows accent.
+
+Out of scope (moved to PR 4): removing the orphaned `data-next`/`data-again` markup and the dead old-completion code path in app.ts (lines 472-474, 501, 525, 552, 636 + dom cache 69-71). It is entangled with live code and is cleanup, not a bug fix.
+
+---
+
+### Task 1: Fix /random correct-answer crash
+
+**Files:**
+- Modify: `src/app.ts:710-720` (the `else` branch in `handleGuess`)
+- Test: `e2e/specs/random.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `e2e/specs/random.spec.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+import { solvePuzzle } from "../helpers/solve";
+import { expectActiveScreen } from "../helpers/screens";
+
+test.describe("/random", () => {
+  test("solving a random puzzle lands on completion without error", async ({ page }) => {
+    const tokenResp = page.waitForResponse((r) => r.url().includes("/api/puzzle/random"));
+    await page.goto("/random");
+    const token = (await (await tokenResp).json()).token as string;
+
+    await solvePuzzle(page, { token });
+
+    // The feedback line must NOT show the generic error.
+    const feedback = page.locator("[data-feedback]");
+    await expect(feedback).not.toHaveText(/something went wrong/i);
+    // Completion screen is shown, heading reflects a solved random puzzle.
+    await expectActiveScreen(page, "completion");
+    await expect(page.locator("[data-completion-heading]")).toHaveText(/solved/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:e2e -- e2e/specs/random.spec.ts --project=chromium`
+Expected: FAIL — feedback shows "Something went wrong" and/or no completion screen is active (the `replaceRoute('/solved')` throw).
+
+- [ ] **Step 3: Apply the fix**
+
+In `src/app.ts`, replace the `else` branch at lines 710-720:
+
+```ts
+      } else {
+        // Today's solve: paint the completion screen and replace history (no /play
+        // entry to back into; back from /solved goes to /welcome, which itself
+        // redirects to /solved post-solve so the back lands on the same screen
+        // — effectively making /solved the post-solve home).
+        renderCompletion(gameState.puzzleNum ?? 0, tries, !!gameState.isRandom);
+        // Fire sync — never inside celebrateOcto's callback. If celebration is
+        // interrupted (page hidden, rAF paused) the user could otherwise be
+        // stranded on /play with the puzzle solved (#solve-stranding).
+        replaceRoute('/solved');
+      }
+```
+
+with:
+
+```ts
+      } else if (gameState.isRandom) {
+        // /random boots without initRouter (app.ts boot shows the game screen
+        // directly), so the router has no deps and replaceRoute('/solved') would
+        // throw `router not initialized`. Random has no /solved URL anyway — show
+        // the completion screen directly.
+        renderCompletion(gameState.puzzleNum ?? 0, tries, true);
+        showScreen('completion');
+      } else {
+        // Today's solve: paint the completion screen and replace history (no /play
+        // entry to back into; back from /solved goes to /welcome, which itself
+        // redirects to /solved post-solve so the back lands on the same screen
+        // — effectively making /solved the post-solve home).
+        renderCompletion(gameState.puzzleNum ?? 0, tries, false);
+        // Fire sync — never inside celebrateOcto's callback. If celebration is
+        // interrupted (page hidden, rAF paused) the user could otherwise be
+        // stranded on /play with the puzzle solved (#solve-stranding).
+        replaceRoute('/solved');
+      }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test:e2e -- e2e/specs/random.spec.ts --project=chromium`
+Expected: PASS — no error feedback, completion screen active, heading "Puzzle solved!".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app.ts e2e/specs/random.spec.ts
+git commit -m "fix: /random correct answer no longer throws 'something went wrong'
+
+The /random boot path skips initRouter, so the solve flow's replaceRoute('/solved')
+hit ctx()'s 'router not initialized' guard and surfaced the generic error. Show the
+completion screen directly for random solves instead of routing.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add the "Play another random puzzle" entry link
+
+**Files:**
+- Modify: `src/completion.ts` (inside the `if (dom.links)` block, ~lines 175-208)
+- Test: `e2e/specs/random.spec.ts` (add a case)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `test.describe("/random", ...)` block in `e2e/specs/random.spec.ts`:
+
+```ts
+  test("random completion offers the only /random entry link", async ({ page }) => {
+    const tokenResp = page.waitForResponse((r) => r.url().includes("/api/puzzle/random"));
+    await page.goto("/random");
+    const token = (await (await tokenResp).json()).token as string;
+    await solvePuzzle(page, { token });
+
+    const again = page.locator('[data-completion-links] [data-completion-random-again]');
+    await expect(again).toBeVisible();
+    await expect(again).toHaveAttribute("href", "/random");
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:e2e -- e2e/specs/random.spec.ts --project=chromium`
+Expected: FAIL — `[data-completion-random-again]` does not exist.
+
+- [ ] **Step 3: Apply the fix**
+
+In `src/completion.ts`, inside `if (dom.links) { ... }`, after `dom.links.replaceChildren();` and the Show-puzzle block, before the Archive link, add:
+
+```ts
+    // Random is a testing page; its only entry link lives here — replay another
+    // random puzzle. A plain anchor does a full navigation to /random, which
+    // re-runs the cold-boot path (the SPA router is never initialised on /random).
+    if (isRandom) {
+      const again = document.createElement('a');
+      again.href = '/random';
+      again.className = 'btn btn-hollow flex-1';
+      again.dataset.completionRandomAgain = '';
+      again.innerHTML = '<svg aria-hidden="true"><use href="/sprites.svg#icon-puzzle"/></svg>Play another random puzzle';
+      dom.links.appendChild(again);
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test:e2e -- e2e/specs/random.spec.ts --project=chromium`
+Expected: PASS — both random cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/completion.ts e2e/specs/random.spec.ts
+git commit -m "fix: re-add 'Play another random puzzle' entry link on random completion
+
+The redesign rebuilt the completion screen and dropped the only link to /random.
+Render it for random solves; it is intentionally the sole entry point (testing page).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Make shadows follow the theme tokens
+
+**Files:**
+- Modify: `src/tailwind.css` (add tokens to `@theme` block ~lines 35-41; fix octo drop-shadow line 122)
+- Modify: `index.html` (digit boxes lines 241-243)
+- Modify: `src/app.ts` (active/inactive box shadows lines 351, 356-357; keypad button line 384)
+- Modify: `src/welcome.ts` (demo boxes lines 64, 95)
+- Test: `e2e/specs/shadow-theme.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `e2e/specs/shadow-theme.spec.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+// Force light mode so the Berry *light* value (#de1f46 = rgb(222,31,70)) applies.
+test.use({ colorScheme: "light" });
+
+test("active digit-box shadow follows the selected accent colour", async ({ page }) => {
+  // /random loads the game screen with live digit boxes.
+  await page.goto("/random");
+  await expect(page.locator('[data-digit="0"]')).toBeVisible();
+
+  // Pick the Berry accent via the menu.
+  await page.locator("[data-menu-btn]").click();
+  await page.locator('[data-swatches] [data-colour="Berry"]').click();
+  await page.locator("[data-menu-btn]").click(); // close menu
+
+  // Activate box 0 — this applies the active-state shadow.
+  await page.locator('[data-digit="0"]').click();
+
+  const shadow = await page
+    .locator('[data-digit="0"]')
+    .evaluate((el) => getComputedStyle(el).boxShadow);
+
+  // Berry, not the hardcoded Lime (rgb(10,133,10)).
+  expect(shadow).toMatch(/222,\s*31,\s*70/);
+  expect(shadow).not.toMatch(/10,\s*133,\s*10/);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:e2e -- e2e/specs/shadow-theme.spec.ts --project=chromium`
+Expected: FAIL — computed shadow is `rgb(10, 133, 10)` (Lime), not Berry.
+
+- [ ] **Step 3: Add the shadow tokens**
+
+In `src/tailwind.css`, inside the `@theme { ... }` block (after `--color-border:` at line 40), add:
+
+```css
+  /* Offset shadows derive from theme tokens so they follow dark mode and the
+     selected accent. --color-text / --color-accent are live custom properties
+     (accent is set per-swatch in colours.ts), so color-mix re-resolves on theme
+     and accent changes — no dark: variant needed. */
+  --shadow-box:        3px 3px 0 color-mix(in srgb, var(--color-text) 12%, transparent);
+  --shadow-box-active: 3px 3px 0 color-mix(in srgb, var(--color-accent) 30%, transparent);
+  --shadow-key:        2px 2px 0 color-mix(in srgb, var(--color-text) 12%, transparent);
+```
+
+- [ ] **Step 4: Fix the octo drop-shadow**
+
+In `src/tailwind.css` line 122, replace:
+
+```css
+    filter: drop-shadow(0.125rem 0.1875rem 0 rgba(38, 38, 36, 0.25));
+```
+
+with:
+
+```css
+    filter: drop-shadow(0.125rem 0.1875rem 0 color-mix(in srgb, var(--color-text) 25%, transparent));
+```
+
+- [ ] **Step 5: Swap the digit-box shadows in index.html**
+
+In `index.html`, on each of the three digit-box `<div>`s (lines 241, 242, 243), replace the class fragment:
+
+```
+shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946]
+```
+
+with:
+
+```
+shadow-box
+```
+
+- [ ] **Step 6: Swap the box shadows in app.ts**
+
+In `src/app.ts`, replace the active-state line 351:
+
+```ts
+  el.classList.toggle("shadow-[3px_3px_0_rgba(10,133,10,0.3)]", i === activeBox);
+```
+
+with:
+
+```ts
+  el.classList.toggle("shadow-box-active", i === activeBox);
+```
+
+Then replace the inactive-state lines 356-357:
+
+```ts
+  el.classList.toggle("shadow-[3px_3px_0_rgba(38,38,36,0.12)]", i !== activeBox);
+  el.classList.toggle("dark:shadow-[3px_3px_0_#494946]", i !== activeBox);
+```
+
+with a single toggle:
+
+```ts
+  el.classList.toggle("shadow-box", i !== activeBox);
+```
+
+Then update the keypad-button class at line 384 — replace:
+
+```ts
+        : 'bg-surface text-text border-border shadow-[2px_2px_0_rgba(38,38,36,0.12)] dark:shadow-[2px_2px_0_#494946]'
+```
+
+with:
+
+```ts
+        : 'bg-surface text-text border-border shadow-key'
+```
+
+- [ ] **Step 7: Swap the welcome demo shadows**
+
+In `src/welcome.ts`, on both demo box `<div>`s (lines 64 and 95), replace the class fragment:
+
+```
+shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946]
+```
+
+with:
+
+```
+shadow-box
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `npm run test:e2e -- e2e/specs/shadow-theme.spec.ts --project=chromium`
+Expected: PASS — computed shadow matches Berry `rgb(222, 31, 70)`.
+
+- [ ] **Step 9: Manually verify dark mode + all accents**
+
+Run: `npm run e2e:serve` (if not already running), then drive a quick visual check:
+
+```bash
+node -e '
+import("@playwright/test").then(async ({ chromium }) => {
+  const b = await chromium.launch();
+  for (const scheme of ["light","dark"]) {
+    const p = await b.newPage({ colorScheme: scheme });
+    await p.goto("http://localhost:4173/random");
+    await p.locator("[data-digit=\"0\"]").click();
+    await p.screenshot({ path: `/tmp/shadow-${scheme}.png`, fullPage: true });
+    await p.close();
+  }
+  await b.close();
+});'
+```
+
+Read `/tmp/shadow-light.png` and `/tmp/shadow-dark.png`. Confirm: the active box shadow is the accent colour, inactive box/keypad/octo shadows are visible (not invisible) in dark mode. Delete the screenshots when done: `rm -f /tmp/shadow-*.png`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/tailwind.css index.html src/app.ts src/welcome.ts e2e/specs/shadow-theme.spec.ts
+git commit -m "fix: shadows follow theme tokens (accent + dark mode)
+
+Active digit-box shadow hardcoded Lime green, so it ignored Berry/Blue/Violet
+accents. Replace hardcoded offset shadows with --shadow-* tokens that color-mix
+off --color-text / --color-accent, so they track the accent and dark mode. Octo
+drop-shadow now derives from --color-text too (was invisible in dark mode).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full verification + open PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type-check and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: no type errors; build succeeds.
+
+- [ ] **Step 2: Run the full e2e suite**
+
+Run: `npm run test:e2e`
+Expected: all specs pass (the two new specs plus the existing suite — confirm no regression).
+
+- [ ] **Step 3: Self-review the diff**
+
+Run: `git diff origin/staging...HEAD --stat` and read the full diff. Confirm: only the four source files + two new specs changed; no stray `_tmp_*` files; no hardcoded `rgba(10,133,10` / `#494946` / `rgba(38,38,36` offset-shadow values remain in the swapped files (`grep -rn "rgba(10,133,10\|#494946" src/ index.html` returns nothing).
+
+- [ ] **Step 4: Push and open the PR**
+
+Per [docs/GIT-WORKFLOW.md](../../GIT-WORKFLOW.md): the branch is off `staging`; push and open a PR into `staging`. Do NOT merge — the user merges. Run the DA review (fresh-context subagent) → self-review gates first, per CLAUDE.md, since this touches multiple files and changes puzzle-completion logic + CSS/theming.
+
+```bash
+git push -u origin dev/post-redesign-stabilisation
+gh pr create --base staging --title "Fix /random solve crash + entry link + theme-aware shadows" --body "<summary + test evidence>"
+```
+
+---
+
+## Self-review (planning)
+
+- **Spec coverage:** PR 1 items from the spec — /random submit fix (Task 1), /random entry link (Task 2), shadow token fix (Task 3), a regression test per bug (Tasks 1-3), light+dark verification (Task 3 Step 9). Dead-markup removal is explicitly deferred to PR 4 (documented above + spec note). Covered.
+- **Placeholder scan:** PR body summary in Task 4 Step 4 is the only `<...>` — it's a human-written PR description, filled at PR time, not a code placeholder. All code/test steps are concrete.
+- **Type/name consistency:** `data-completion-random-again` used consistently in Task 2 fix and test. `shadow-box` / `shadow-box-active` / `shadow-key` token names match between tailwind.css definitions (Task 3 Step 3) and the swaps (Steps 5-7) and the test expectation (Berry rgb). `showScreen` already imported (verified). `solvePuzzle` / `expectActiveScreen` / `readAnswer` signatures match the existing helpers.

--- a/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
+++ b/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
@@ -123,8 +123,11 @@ ordering. Decide during planning.
   (pre-redesign docs branch; its April /random fix `a8d0be8` is superseded). Confirm each is
   merged before deletion.
 - Retire or refresh `PROGRESS.md` (stale April session; ROADMAP already covers working state).
-- Update `ROADMAP.md`: add redesign #226 + /migrate #231 to "shipped"; add /random as a
-  low-priority bug; confirm the shadows item is the already-tracked one.
+- Update `ROADMAP.md` "Recently shipped": add the redesign (#226) and /migrate (#231) — the two
+  biggest recent items, currently missing — **and** the PR 1 (#233) bug fixes now that they've
+  shipped: the /random correct-answer crash + restored entry link, and theme-aware shadows.
+  Record /random as a fixed regression (shipped), not an open bug. The shadows item was the one
+  already tracked as a known bug — move it from open to shipped too.
 - Fix docs: `DESIGN-SYSTEM.md` (Quicksand fonts, 4 accent colours), `ARCHITECTURE.md` /
   `URL-ARCHITECTURE.md` (`cw-*` → `dlng_*` keys), minor `README.md` naming.
 - Document the feedback → triage dev process in [FEEDBACK.md](../../FEEDBACK.md), replacing

--- a/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
+++ b/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
@@ -76,10 +76,18 @@ One PR, a regression test per bug.
 3. In [completion.ts](../../../src/completion.ts), when `isRandom`, render a "Play another
    random puzzle" link → `/random` in the `data-completion-links` area. This is the sole
    `/random` entry point.
-4. Remove the orphaned legacy markup ([index.html:281-288](../../../index.html#L281-L288),
-   `data-next` / `data-again`).
-5. e2e: drive `/random` end-to-end — load → solve → completion shows and the "play another"
-   link points to `/random`.
+4. e2e: drive `/random` end-to-end — load → solve → completion shows without the
+   "Something went wrong" error, and the "play another" link points to `/random`.
+
+   Root cause (confirmed in planning): `/random` boots without `initRouter`
+   ([app.ts:972](../../../src/app.ts#L972)), so the solve path's `replaceRoute('/solved')`
+   hits `ctx()`'s `router not initialized` throw ([router.ts:67](../../../src/router.ts#L67)).
+   Fix shows the completion screen directly for random solves.
+
+   Note: the orphaned `data-next` / `data-again` markup ([index.html:281-288](../../../index.html#L281-L288))
+   is **moved to PR 4** — it is still poked by a dead old-completion code path in app.ts
+   (lines 472-474, 501, 525, 552, 636 + dom cache 69-71), so removing it cleanly is cleanup,
+   not a ship-fast bug fix.
 
 **Shadows**
 6. Define `--shadow-*` tokens in [tailwind.css](../../../src/tailwind.css) `@theme`
@@ -133,7 +141,12 @@ ordering. Decide during planning.
   (`DELETE FROM feedback WHERE host LIKE '%workers.dev%';`) — low value since it's filtered
   from the dashboard; do only if tidying the table is wanted.
 
-(The dead-markup removal lives in PR 1, not here, since it's coupled to the /random fix.)
+- Remove the orphaned `data-next` / `data-again` markup ([index.html:281-288](../../../index.html#L281-L288))
+  **and** the dead old-completion code path that pokes it in app.ts (lines 472-474, 501, 525, 552,
+  636 + the `next` / `nextNumber` / `again` dom cache at 69-71). Moved here from PR 1: the markup
+  is entangled with live (no-op) code, so untangling it is cleanup, not a bug fix. Verify the new
+  completion screen ([completion.ts](../../../src/completion.ts)) fully covers what the old path did
+  (countdown / next-puzzle text) before deleting.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
+++ b/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
@@ -1,0 +1,130 @@
+# Post-redesign stabilisation — design
+
+**Date:** 2026-06-28
+**Branch base:** `staging`
+**Status:** approved (sequencing per PR 1 → 3 → 2 → 4)
+
+The three-screen redesign (`cd206f9`, #226) and the `/migrate` hand-off (#231) shipped
+to production with a small set of regressions and left several docs stale. This program
+fixes the user-facing bugs first, then closes the QA gap that let them ship, then refreshes
+docs and cleans the repo.
+
+It is split into four PRs. PR 1 is the priority and ships fast. PR 3 (the CI gate) follows
+PR 1 so the gate exists to catch the *next* regression — the /random bug is exactly the kind
+a gate would have caught.
+
+---
+
+## Findings (verified)
+
+- **/random is partly broken and unreachable.** The page and worker API are fine — a live
+  `POST /api/guess` with a fresh random token returns `{correct:false}` (200), and
+  `/random` cold-loads into a working game screen. Two real problems:
+  1. **No entry point.** The only link to `/random` was "Play another random puzzle" on the
+     old completion screen. The redesign rebuilt completion ([completion.ts](../../../src/completion.ts)
+     renders only `data-completion-*` nodes) and dropped it. The old markup is now orphaned
+     and permanently `hidden` in the *game* section ([index.html:281-288](../../../index.html#L281-L288)).
+  2. **Submit fails with "Something went wrong" (friend report).** Client-side error from
+     [app.ts:654/669/742](../../../src/app.ts#L654). Prime suspect: the correct-guess solve
+     path calls `replaceRoute('/solved')` ([app.ts:719](../../../src/app.ts#L719)), but a
+     random solve writes no daily history entry, so `resolveRoute('/solved')` has no
+     `todayEntry` and bounces to `welcome`. Any throw in that branch is caught and rendered
+     as the generic error. Reproduce locally before fixing — do not guess the exact line.
+
+- **Shadows don't match theme.** ~10 hardcoded shadow colours (`rgba(38,38,36,...)` light,
+  non-token `#494946` dark) instead of theme tokens, so shadows are wrong/invisible in dark
+  mode. Files: [tailwind.css:122](../../../src/tailwind.css#L122),
+  [app.ts:351,356-357,384](../../../src/app.ts#L351),
+  [welcome.ts:64,95](../../../src/welcome.ts#L64),
+  [worker/stats.ts:197](../../../src/worker/stats.ts#L197).
+
+- **No e2e guards the /random regression.** Existing specs check the page renders, not that
+  the UI can reach it or that a random solve completes. This gap is the case for PRs 2–3.
+
+- **Docs stale:** `DESIGN-SYSTEM.md` (claims "green accent only" + DM Sans/Inconsolata; real
+  state is 4 accent colours + Quicksand), `ARCHITECTURE.md` / `URL-ARCHITECTURE.md`
+  (`cw-*` localStorage keys, now `dlng_*`), `PROGRESS.md` (frozen on an April session),
+  `ROADMAP.md` ("shipped" list omits the redesign #226 and /migrate #231; no bugs tracked).
+
+---
+
+## Design decision: /random is a testing page
+
+`/random` is intentionally a low-traffic testing page. Its **only** entry link lives on the
+random completion screen ("Play another random puzzle" → `/random`), shown only after solving
+a random puzzle. No link is added to the daily completion screen or anywhere else.
+
+---
+
+## PR 1 — Bug fixes (priority, ship fast)
+
+One PR, a regression test per bug.
+
+**/random**
+1. Reproduce the friend's submit error locally (`npm run preview`, drive `/random`, solve it).
+   Confirm the exact failing line before changing code.
+2. Fix the random solve flow so a correct guess lands on (and stays on) the completion screen
+   without the "Something went wrong" error and without bouncing to welcome.
+3. In [completion.ts](../../../src/completion.ts), when `isRandom`, render a "Play another
+   random puzzle" link → `/random` in the `data-completion-links` area. This is the sole
+   `/random` entry point.
+4. Remove the orphaned legacy markup ([index.html:281-288](../../../index.html#L281-L288),
+   `data-next` / `data-again`).
+5. e2e: drive `/random` end-to-end — load → solve → completion shows and the "play another"
+   link points to `/random`.
+
+**Shadows**
+6. Define `--shadow-*` tokens in [tailwind.css](../../../src/tailwind.css) `@theme`
+   (`color-mix` off `--color-text` / `--color-accent`), with dark overrides.
+7. Swap the ~10 hardcoded shadow values across the 4 files for the tokens.
+8. Verify: Playwright screenshots in light + dark, both themes.
+
+**QA level:** critical-path Playwright subset (the new /random e2e + a visual dark-mode check).
+
+## PR 3 — CI smoke gate (right after PR 1)
+
+GitHub Action on PRs targeting `main`: build, run a fast critical-path Playwright subset
+against the branch preview (`{branch}-clumeral-game.jevawin.workers.dev`), block merge on red.
+The full e2e matrix stays manual and proportional, per the QA-level rule in CLAUDE.md.
+
+Open question for plan phase: run against the deployed preview URL vs. a local `vite preview`
+build in the Action. Preview URL is closer to prod; local build is faster and avoids deploy
+ordering. Decide during planning.
+
+## PR 2 — QA coverage map → spec
+
+1. Build a coverage matrix: every screen (welcome / game / completion) and flow (daily solve,
+   random, archive, midnight rollover, PWA, theme/shadows, walkthrough) × tested-or-not,
+   mapped to existing specs in `e2e/` and `tests/`.
+2. The gaps drive what to add — expected: random entry/solve, completion screen, theme/shadow
+   visual checks.
+3. Update [the QA design spec](2026-05-31-playwright-qa-regression-design.md) and add the
+   missing specs.
+
+## PR 4 — Cleanup + doc refresh
+
+- Prune merged branches: local `new-design`, `staging`; remote `chore/roadmap-217`
+  (pre-redesign docs branch; its April /random fix `a8d0be8` is superseded). Confirm each is
+  merged before deletion.
+- Retire or refresh `PROGRESS.md` (stale April session; ROADMAP already covers working state).
+- Update `ROADMAP.md`: add redesign #226 + /migrate #231 to "shipped"; add /random as a
+  low-priority bug; confirm the shadows item is the already-tracked one.
+- Fix docs: `DESIGN-SYSTEM.md` (Quicksand fonts, 4 accent colours), `ARCHITECTURE.md` /
+  `URL-ARCHITECTURE.md` (`cw-*` → `dlng_*` keys), minor `README.md` naming.
+
+(The dead-markup removal lives in PR 1, not here, since it's coupled to the /random fix.)
+
+---
+
+## Out of scope
+
+- No worker/API changes — the random API verified working in production.
+- No redesign visual changes beyond the shadow tokens.
+- No new e2e engines or infra beyond the smoke gate.
+
+## Risks
+
+- The /random submit error is not yet reproduced line-exact; PR 1 must reproduce before
+  fixing, not patch the symptom.
+- Branch pruning: verify merged status before any delete; never touch `main` / `staging`
+  remote protection.

--- a/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
+++ b/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
@@ -46,6 +46,14 @@ a gate would have caught.
   (`cw-*` localStorage keys, now `dlng_*`), `PROGRESS.md` (frozen on an April session),
   `ROADMAP.md` ("shipped" list omits the redesign #226 and /migrate #231; no bugs tracked).
 
+- **Feedback is already clean — nothing to import.** The Google Sheet CSV (pre-migration
+  snapshot) holds exactly the 11 genuine rows already loaded by
+  `migrations/0002_import_legacy_feedback.sql`; the rest are test/garbage (E2E smoke,
+  keyboard-mashes, "testing"). Live remote D1 confirms: 11 `host = clumeral.com` rows
+  (newest the 1 June "Streak bug."), no production feedback since the migration — new
+  feedback now lands directly in D1 via `/api/feedback`. One stray preview-host test row
+  (`*.workers.dev`) sits in prod D1; the dashboard already filters it out by default.
+
 ---
 
 ## Design decision: /random is a testing page
@@ -111,6 +119,19 @@ ordering. Decide during planning.
   low-priority bug; confirm the shadows item is the already-tracked one.
 - Fix docs: `DESIGN-SYSTEM.md` (Quicksand fonts, 4 accent colours), `ARCHITECTURE.md` /
   `URL-ARCHITECTURE.md` (`cw-*` → `dlng_*` keys), minor `README.md` naming.
+- Document the feedback → triage dev process in [FEEDBACK.md](../../FEEDBACK.md), replacing
+  the "no triage state yet" placeholder section:
+  1. **Review feedback** → create GitHub issues as needed → mark the feedback row complete
+     (once it's captured in GitHub).
+  2. **Review new GitHub issues** → prioritise → update local `ROADMAP.md`.
+  3. **Work from the roadmap.**
+  Note the dependency: step 1's "mark complete" needs the open/resolved state from
+  [#225](https://github.com/jevawin/clumeral-game/issues/225), still open. Until #225 ships,
+  capture-to-GitHub happens but rows can't be marked done — call that out in the doc.
+- Feedback data: no import needed (already clean — see Findings). Optional: delete the single
+  stray preview-host test row from prod D1
+  (`DELETE FROM feedback WHERE host LIKE '%workers.dev%';`) — low value since it's filtered
+  from the dashboard; do only if tidying the table is wanted.
 
 (The dead-markup removal lives in PR 1, not here, since it's coupled to the /random fix.)
 

--- a/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
+++ b/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
@@ -2,7 +2,16 @@
 
 **Date:** 2026-06-28
 **Branch base:** `staging`
-**Status:** approved (sequencing per PR 1 → 3 → 2 → 4)
+**Status:** in progress (sequencing per PR 1 → 3 → 2 → 4)
+
+### Progress
+- **PR 1 — bug fixes:** ✅ done. PR [#233](https://github.com/jevawin/clumeral-game/pull/233)
+  → `staging` (branch `dev/post-redesign-stabilisation`). /random crash fix + restored entry
+  link + theme-aware shadows. Full suite green (unit 120, e2e 208). Plan:
+  [docs/superpowers/plans/2026-06-28-pr1-random-and-shadow-fixes.md](../plans/2026-06-28-pr1-random-and-shadow-fixes.md).
+- **PR 3 — CI smoke gate:** ⬜ next.
+- **PR 2 — QA coverage map → spec:** ⬜ pending.
+- **PR 4 — cleanup + doc refresh:** ⬜ pending.
 
 The three-screen redesign (`cd206f9`, #226) and the `/migrate` hand-off (#231) shipped
 to production with a small set of regressions and left several docs stale. This program

--- a/e2e/helpers/random.ts
+++ b/e2e/helpers/random.ts
@@ -1,0 +1,31 @@
+import type { Page } from "@playwright/test";
+import { expect } from "../fixtures.ts";
+
+/**
+ * Load /random, solve it via the dev helper, and click submit — race-free.
+ *
+ * The race we avoid: `_devFillAnswer()` reads `gameState.token`, which
+ * `startRandomPuzzle()` only sets inside the JS callback that runs AFTER the
+ * `/api/puzzle/random` HTTP response arrives. Waiting on the response alone
+ * (as the tests used to) lets the fill run before the puzzle is initialised,
+ * so the digit boxes never resolve to size 1 and `[data-submit]` stays hidden
+ * — reliably on webkit.
+ *
+ * The reliable readiness signal is the clue list: `renderClues()` (run inside
+ * `startRandomPuzzle()`, after the token is set) removes `aria-busy` from
+ * `[data-clue-list]`. Once that attribute is gone the token is guaranteed set.
+ */
+export async function solveRandom(page: Page): Promise<void> {
+  await page.goto("/random");
+  // Game is ready once clues have rendered (token is set by then).
+  await expect(page.locator("[data-clue-list]")).not.toHaveAttribute(
+    "aria-busy",
+    "true",
+  );
+  await page.waitForFunction(() => typeof window._devFillAnswer === "function");
+  await page.evaluate(() => window._devFillAnswer());
+  // Wait for VISIBLE (not just enabled) — checkSubmit() unhides the wrap only
+  // when all three boxes are size 1.
+  await expect(page.locator("[data-submit]")).toBeVisible();
+  await page.locator("[data-submit]").click();
+}

--- a/e2e/specs/random.spec.ts
+++ b/e2e/specs/random.spec.ts
@@ -1,19 +1,10 @@
 import { test, expect } from "../fixtures.ts";
 import { expectActiveScreen } from "../helpers/screens.ts";
+import { solveRandom } from "../helpers/random.ts";
 
 test.describe("/random", () => {
   test("solving a random puzzle lands on completion without error", async ({ page }) => {
-    // Wait for the /api/puzzle/random response (the dev helper reads the token below).
-    const tokenResp = page.waitForResponse((r) => r.url().includes("/api/puzzle/random"));
-    await page.goto("/random");
-    await tokenResp;
-    // Fill the correct answer via the dev helper, which reads gameState.token and
-    // fetches /api/dev/answer for the served random puzzle (race-free — no need to
-    // read the response body, which Chromium evicts for sub-resource fetches).
-    await page.waitForFunction(() => typeof window._devFillAnswer === "function");
-    await page.evaluate(() => window._devFillAnswer());
-    await expect(page.locator("[data-submit]")).toBeEnabled();
-    await page.locator("[data-submit]").click();
+    await solveRandom(page);
 
     // The feedback line must NOT show the generic error.
     const feedback = page.locator("[data-feedback]");
@@ -24,13 +15,7 @@ test.describe("/random", () => {
   });
 
   test("random completion shows the 'play another random puzzle' entry link", async ({ page }) => {
-    const tokenResp = page.waitForResponse((r) => r.url().includes("/api/puzzle/random"));
-    await page.goto("/random");
-    await tokenResp;
-    await page.waitForFunction(() => typeof window._devFillAnswer === "function");
-    await page.evaluate(() => window._devFillAnswer());
-    await expect(page.locator("[data-submit]")).toBeEnabled();
-    await page.locator("[data-submit]").click();
+    await solveRandom(page);
 
     await expectActiveScreen(page, "completion");
     // The only entry link to /random lives here on the random completion screen.

--- a/e2e/specs/random.spec.ts
+++ b/e2e/specs/random.spec.ts
@@ -22,4 +22,20 @@ test.describe("/random", () => {
     await expectActiveScreen(page, "completion");
     await expect(page.locator("[data-completion-heading]")).toHaveText(/solved/i);
   });
+
+  test("random completion shows the 'play another random puzzle' entry link", async ({ page }) => {
+    const tokenResp = page.waitForResponse((r) => r.url().includes("/api/puzzle/random"));
+    await page.goto("/random");
+    await tokenResp;
+    await page.waitForFunction(() => typeof window._devFillAnswer === "function");
+    await page.evaluate(() => window._devFillAnswer());
+    await expect(page.locator("[data-submit]")).toBeEnabled();
+    await page.locator("[data-submit]").click();
+
+    await expectActiveScreen(page, "completion");
+    // The only entry link to /random lives here on the random completion screen.
+    const again = page.locator("[data-completion-links] [data-completion-random-again]");
+    await expect(again).toBeVisible();
+    await expect(again).toHaveAttribute("href", "/random");
+  });
 });

--- a/e2e/specs/random.spec.ts
+++ b/e2e/specs/random.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "../fixtures.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+
+test.describe("/random", () => {
+  test("solving a random puzzle lands on completion without error", async ({ page }) => {
+    // Wait for the /api/puzzle/random response (the dev helper reads the token below).
+    const tokenResp = page.waitForResponse((r) => r.url().includes("/api/puzzle/random"));
+    await page.goto("/random");
+    await tokenResp;
+    // Fill the correct answer via the dev helper, which reads gameState.token and
+    // fetches /api/dev/answer for the served random puzzle (race-free — no need to
+    // read the response body, which Chromium evicts for sub-resource fetches).
+    await page.waitForFunction(() => typeof window._devFillAnswer === "function");
+    await page.evaluate(() => window._devFillAnswer());
+    await expect(page.locator("[data-submit]")).toBeEnabled();
+    await page.locator("[data-submit]").click();
+
+    // The feedback line must NOT show the generic error.
+    const feedback = page.locator("[data-feedback]");
+    await expect(feedback).not.toHaveText(/something went wrong/i);
+    // Completion screen is shown, heading reflects a solved random puzzle.
+    await expectActiveScreen(page, "completion");
+    await expect(page.locator("[data-completion-heading]")).toHaveText(/solved/i);
+  });
+});

--- a/e2e/specs/shadow-theme.spec.ts
+++ b/e2e/specs/shadow-theme.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "../fixtures.ts";
+
+// Force light mode so the Berry *light* value (#de1f46 = rgb(222,31,70)) applies.
+test.use({ colorScheme: "light" });
+
+test("active digit-box shadow follows the selected accent colour", async ({ page }) => {
+  // /random loads the game screen with live digit boxes.
+  await page.goto("/random");
+  await expect(page.locator('[data-digit="0"]')).toBeVisible();
+
+  // Pick the Berry accent via the menu.
+  await page.locator("[data-menu-btn]").click();
+  await page.locator('[data-swatches] [data-colour="Berry"]').click();
+  await page.locator("[data-menu-btn]").click(); // close menu
+
+  // Activate box 0 — this applies the active-state shadow.
+  await page.locator('[data-digit="0"]').click();
+
+  const shadow = await page
+    .locator('[data-digit="0"]')
+    .evaluate((el) => getComputedStyle(el).boxShadow);
+
+  // The active shadow now derives from --color-accent via color-mix, which
+  // Chromium serialises in the srgb colour space (e.g.
+  // "color(srgb 0.870588 0.121569 0.27451 / 0.3)") rather than as rgb(). Parse
+  // the channels back to 0–255 and assert they match Berry (222, 31, 70), and
+  // crucially NOT the old hardcoded Lime (10, 133, 10).
+  const srgb = shadow.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/);
+  expect(srgb, `expected an srgb color-mix shadow, got: ${shadow}`).not.toBeNull();
+  const [r, g, b] = srgb!.slice(1, 4).map((c) => Math.round(parseFloat(c) * 255));
+
+  // Berry, not the hardcoded Lime.
+  expect({ r, g, b }).toEqual({ r: 222, g: 31, b: 70 });
+  expect({ r, g, b }).not.toEqual({ r: 10, g: 133, b: 10 });
+});

--- a/index.html
+++ b/index.html
@@ -238,9 +238,9 @@
 
             <!-- Digit boxes -->
             <div data-digits class="flex gap-2 w-full mt-5" role="group" aria-label="Digit entry boxes">
-              <div class="flex-1 aspect-square [container-type:inline-size] flex items-center justify-center bg-surface border-[1.5px] border-border rounded shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946] cursor-pointer touch-manipulation" data-digit="0" role="button" tabindex="0" aria-label="Hundreds digit" aria-expanded="false"></div>
-              <div class="flex-1 aspect-square [container-type:inline-size] flex items-center justify-center bg-surface border-[1.5px] border-border rounded shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946] cursor-pointer touch-manipulation" data-digit="1" role="button" tabindex="0" aria-label="Tens digit" aria-expanded="false"></div>
-              <div class="flex-1 aspect-square [container-type:inline-size] flex items-center justify-center bg-surface border-[1.5px] border-border rounded shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946] cursor-pointer touch-manipulation" data-digit="2" role="button" tabindex="0" aria-label="Units digit" aria-expanded="false"></div>
+              <div class="flex-1 aspect-square [container-type:inline-size] flex items-center justify-center bg-surface border-[1.5px] border-border rounded shadow-box cursor-pointer touch-manipulation" data-digit="0" role="button" tabindex="0" aria-label="Hundreds digit" aria-expanded="false"></div>
+              <div class="flex-1 aspect-square [container-type:inline-size] flex items-center justify-center bg-surface border-[1.5px] border-border rounded shadow-box cursor-pointer touch-manipulation" data-digit="1" role="button" tabindex="0" aria-label="Tens digit" aria-expanded="false"></div>
+              <div class="flex-1 aspect-square [container-type:inline-size] flex items-center justify-center bg-surface border-[1.5px] border-border rounded shadow-box cursor-pointer touch-manipulation" data-digit="2" role="button" tabindex="0" aria-label="Units digit" aria-expanded="false"></div>
             </div>
 
             <!-- Keypad -->

--- a/src/app.ts
+++ b/src/app.ts
@@ -707,12 +707,19 @@ async function handleGuess() {
         // /solved is reserved for today's puzzle (overall stats live there).
         // Render the minimal solved-replay view inline.
         showCompletedState(tries, gameState.date);
+      } else if (gameState.isRandom) {
+        // /random boots without initRouter (app.ts boot shows the game screen
+        // directly), so the router has no deps and replaceRoute('/solved') would
+        // throw `router not initialized`. Random has no /solved URL anyway — show
+        // the completion screen directly.
+        renderCompletion(gameState.puzzleNum ?? 0, tries, true);
+        showScreen('completion');
       } else {
         // Today's solve: paint the completion screen and replace history (no /play
         // entry to back into; back from /solved goes to /welcome, which itself
         // redirects to /solved post-solve so the back lands on the same screen
         // — effectively making /solved the post-solve home).
-        renderCompletion(gameState.puzzleNum ?? 0, tries, !!gameState.isRandom);
+        renderCompletion(gameState.puzzleNum ?? 0, tries, false);
         // Fire sync — never inside celebrateOcto's callback. If celebration is
         // interrupted (page hidden, rAF paused) the user could otherwise be
         // stranded on /play with the puzzle solved (#solve-stranding).

--- a/src/app.ts
+++ b/src/app.ts
@@ -348,13 +348,12 @@ function renderBox(i: number): void {
 
   // Active state: accent border + accent shadow
   el.classList.toggle("border-accent", i === activeBox);
-  el.classList.toggle("shadow-[3px_3px_0_rgba(10,133,10,0.3)]", i === activeBox);
-  // Restore default border+shadow when not active. Dark uses a solid grey
-  // (#494946 = the border colour composited over the surface) so the offset
-  // shadow stays visible against the black page background.
+  el.classList.toggle("shadow-box-active", i === activeBox);
+  // Restore default border+shadow when not active. shadow-box derives from
+  // --color-text via color-mix, so it stays visible against the dark page
+  // background without a separate dark variant.
   el.classList.toggle("border-border", i !== activeBox);
-  el.classList.toggle("shadow-[3px_3px_0_rgba(38,38,36,0.12)]", i !== activeBox);
-  el.classList.toggle("dark:shadow-[3px_3px_0_#494946]", i !== activeBox);
+  el.classList.toggle("shadow-box", i !== activeBox);
 
   el.setAttribute("aria-expanded", i === activeBox ? "true" : "false");
 }
@@ -381,7 +380,7 @@ function buildKeypad() {
     btn.className = `h-12 rounded-sm font-mono text-lg font-normal border-[1.5px] touch-manipulation active:translate-x-[2px] active:translate-y-[2px] active:shadow-none ${
       elim
         ? 'bg-surface text-text/25 border-border shadow-none'
-        : 'bg-surface text-text border-border shadow-[2px_2px_0_rgba(38,38,36,0.12)] dark:shadow-[2px_2px_0_#494946]'
+        : 'bg-surface text-text border-border shadow-key'
     }`;
     btn.textContent = String(d);
     btn.setAttribute("data-key", String(d));

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -198,6 +198,18 @@ export function renderCompletion(
       dom.links.appendChild(a);
     }
 
+    // Random is a testing page; its only entry link lives here — replay another
+    // random puzzle. A plain anchor does a full navigation to /random, which
+    // re-runs the cold-boot path (the SPA router is never initialised on /random).
+    if (isRandom) {
+      const again = document.createElement('a');
+      again.href = '/random';
+      again.className = 'btn btn-hollow flex-1';
+      again.dataset.completionRandomAgain = '';
+      again.innerHTML = '<svg aria-hidden="true"><use href="/sprites.svg#icon-puzzle"/></svg>Play another random puzzle';
+      dom.links.appendChild(again);
+    }
+
     // Archive link: always present. Renamed from /puzzles to /archive (ARC-01).
     const archive = document.createElement('a');
     archive.href = '/archive';

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -39,6 +39,14 @@
   --color-surface: #FFFFFF;
   --color-border:  rgba(38, 38, 36, 0.12);
 
+  /* Offset shadows derive from theme tokens so they follow dark mode and the
+     selected accent. --color-text / --color-accent are live custom properties
+     (accent is set per-swatch in colours.ts), so color-mix re-resolves on theme
+     and accent changes — no dark: variant needed. */
+  --shadow-box:        3px 3px 0 color-mix(in srgb, var(--color-text) 12%, transparent);
+  --shadow-box-active: 3px 3px 0 color-mix(in srgb, var(--color-accent) 30%, transparent);
+  --shadow-key:        2px 2px 0 color-mix(in srgb, var(--color-text) 12%, transparent);
+
   --font-sans: "Quicksand", system-ui, sans-serif;
   --font-mono: "Inconsolata", ui-monospace, monospace;
 }
@@ -119,7 +127,7 @@ html, body { font-family: var(--font-sans); font-weight: 400; }
     cursor: pointer;
     will-change: transform;
     transform-origin: center bottom;
-    filter: drop-shadow(0.125rem 0.1875rem 0 rgba(38, 38, 36, 0.25));
+    filter: drop-shadow(0.125rem 0.1875rem 0 color-mix(in srgb, var(--color-text) 25%, transparent));
     opacity: 0;
     margin-block-end: 0.15rem;
   }

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -61,7 +61,7 @@ function htpSteps(): string {
       <div>
         <p class="text-base text-text mb-2">2. Open the digit boxes, remove ineligible digits</p>
         <div class="flex items-start gap-2.5">
-          <div class="digit-box flex-1 aspect-square min-w-0 shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946]">
+          <div class="digit-box flex-1 aspect-square min-w-0 shadow-box">
             <div class="digit-box__grid four-col">
               <span class="elim">0</span>
               <span>1</span>
@@ -92,7 +92,7 @@ function htpSteps(): string {
             <span class="text-sm text-text text-center leading-tight">Tap to remove</span>
           </div>
           <span class="text-xl text-text shrink-0 self-center" aria-hidden="true">→</span>
-          <div class="digit-box flex-1 aspect-square min-w-0 shadow-[3px_3px_0_rgba(38,38,36,0.12)] dark:shadow-[3px_3px_0_#494946]"><span class="digit-box__resolved">5</span></div>
+          <div class="digit-box flex-1 aspect-square min-w-0 shadow-box"><span class="digit-box__resolved">5</span></div>
         </div>
       </div>
 


### PR DESCRIPTION
Post-redesign stabilisation — PR 1 of 4 (bug fixes first). Fixes two user-facing regressions from the three-screen redesign and adds a regression test per bug.

## Bugs fixed

**1. `/random` threw "Something went wrong" on a correct answer.**
The `/random` boot path shows the game screen directly and skips `initRouter`, so the router's `deps` is null. A correct guess ran `handleGuess`'s solve branch → `replaceRoute('/solved')` → `ctx()` → `throw 'router not initialized'`, caught and surfaced as the generic error. Fix: for random solves, render and `showScreen('completion')` directly instead of routing (random has no `/solved` URL).

**2. `/random` was unreachable.**
The redesign rebuilt the completion screen and dropped the only link to `/random`. Re-added "Play another random puzzle" on the **random** completion screen — intentionally the sole entry point (`/random` is a low-traffic testing page).

**3. Shadows ignored the selected accent / dark mode.**
The active digit-box shadow hardcoded Lime green (`rgba(10,133,10,0.3)`), so it stayed green on the Berry/Blue/Violet accents; neutral shadows hardcoded a dark grey. Replaced with `--shadow-*` tokens that `color-mix` off `--color-text` / `--color-accent`, so shadows track the accent and dark mode (no `dark:` variant needed). Octo drop-shadow now derives from `--color-text` too (was invisible in dark mode).

## Scope notes
- The SSR stats page (`worker/stats.ts`) uses its own `light-dark()` palette and adapts correctly — left untouched.
- The orphaned `data-next`/`data-again` markup is **deferred to PR 4** — it's entangled with a dead old-completion code path, so removing it is cleanup, not a bug fix.

## Tests
- New `e2e/specs/random.spec.ts` (solve → completion, no error; entry link → `/random`) via a race-free `solveRandom` helper.
- New `e2e/specs/shadow-theme.spec.ts` (active-box shadow follows the Berry accent, not Lime).
- Full run: `tsc` clean · build clean · unit 120/120 · e2e **208 passed, 0 failed** across all 6 engines.

## Reviews
Per-task spec + code-quality reviews passed; full DA architecture review = APPROVE WITH NITS (no blockers).

Includes the design spec + implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)