### PR TITLE
ci: critical-path smoke gate on PRs to main

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -1,0 +1,59 @@
+# Critical-path smoke gate. Runs the structured e2e suite (e2e/specs/**) on a
+# single engine against the production build, and blocks merge on red.
+#
+# Scope is deliberate (see docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md,
+# PR 3): chromium only, all specs. "Fast" comes from dropping 4 of 5 engines —
+# the full browser matrix stays manual and proportional per CLAUDE.md's QA rule.
+#
+# No Cloudflare deploy: Playwright's webServer runs `npm run e2e:serve`
+# (vite build + preview + local D1 seed) and the Cloudflare Vite plugin serves
+# the Worker API in-process, so the gate is self-contained and needs no secrets.
+name: CI smoke gate
+
+on:
+  pull_request:
+    branches: [main]
+
+# A new push to the same PR cancels the in-flight run — no point finishing a
+# gate against superseded code.
+concurrency:
+  group: ci-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-smoke:
+    name: e2e smoke (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Only the engine the gate runs. --with-deps pulls the OS libraries the
+      # browser needs on the runner.
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      # Playwright's webServer builds, seeds local D1, and serves the preview
+      # itself (playwright.config.ts). process.env.CI is set by Actions, which
+      # turns on retries:1, the github + html reporters, and forbidOnly.
+      - name: Run smoke suite
+        run: npm run test:e2e:smoke
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() && failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:e2e:smoke": "playwright test --project=chromium-desktop",
     "build": "vite build",
     "preview": "vite build && vite preview --host --port 4173",
     "e2e:db": "wrangler d1 execute clumeral-feedback --local --command=\"DROP TABLE IF EXISTS feedback;\" && wrangler d1 execute clumeral-feedback --local --file=migrations/0001_create_feedback.sql",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? "github" : "list",
+  // CI: annotate the PR inline (github) AND emit playwright-report/ so the
+  // smoke gate can upload it as a debuggable artifact (embeds on-retry traces).
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
   use: {
     baseURL: `http://localhost:${PORT}`,
     trace: "on-first-retry",


### PR DESCRIPTION
PR 3 of the post-redesign stabilisation program ([design spec](docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md), "PR 3 — CI smoke gate").

## What

Adds a GitHub Actions smoke gate that runs the structured e2e suite on PRs targeting `main` and blocks merge on red.

- **Trigger:** `pull_request` → `main` (guards the `staging → main` promotion).
- **Scope:** chromium-only, all of `e2e/specs/**` (`--project=chromium-desktop`). "Fast" comes from dropping 4 of 5 engines — the full matrix stays manual and proportional per CLAUDE.md's QA rule.
- **Self-contained:** Playwright's `webServer` runs `npm run e2e:serve` (vite build + preview + local D1 seed) and the Cloudflare Vite plugin serves the Worker API in-process. **No Cloudflare deploy, no secrets.**

## Files

- `.github/workflows/ci-smoke.yml` — new workflow (Node 24, install chromium, run subset, upload html report on failure, cancel superseded runs).
- `package.json` — `test:e2e:smoke` script for local/CI parity.
- `playwright.config.ts` — CI now emits `github` + `html` reporters so red runs produce a debuggable artifact with on-retry traces.

## Verification

- `CI=1 npm run test:e2e:smoke` → 38 specs pass in ~10s; `playwright-report/` generated.
- DA review (fresh-context subagent): GO, no Medium+ findings. Confirmed the full flow runs credential-free — `wrangler --local` is offline miniflare, `vite build` needs no secrets.
- Self-review: passed.

## Note

This PR targets `staging`, but the gate triggers on PRs to `main` — so **no check runs on this PR**. Its first live run is the next `staging → main` promotion PR.

Decisions for this PR were confirmed up front: local built preview (not deployed URL), chromium-only all specs, PRs to main only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)