### PR TITLE
QA coverage map + gap specs (post-redesign stabilisation PR 2)

### DIFF
--- a/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
+++ b/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
@@ -21,6 +21,54 @@ Deviations from the design, all deliberate:
   later pass.
 - **Console guard** allowlists external Google-Fonts/SW noise (offline hosts).
 
+## Coverage review — 2026-06-28 (PR 2)
+
+Post-redesign coverage map: every screen × flow against the real specs in `e2e/` and
+`tests/` (not the intended inventory below). Built during PR 2 of the post-redesign
+stabilisation program ([design](2026-06-28-post-redesign-stabilisation-design.md)).
+
+**Well covered** (screen × flow → spec): daily solve (`game-solve`), wrong guess + retry
+(`game-fail`), random load + solve (`random`, `ssr-pages`), archive replay + back
+(`archive`), midnight/local-date rollover (`midnight-rollover`, `welcome`, unit `date`),
+first-play walkthrough (`octopus-walkthrough`), menu burger/feedback/theme/swatch (`menu`),
+completion stats/countdown/links (`completion`, unit `completion-stats`/`completion-links`/
+`archive-stats`), a11y axe + skip-link (`a11y`), PWA single-screen + precache (`pwa-render`,
+unit `sw-precache`), routing scrollRestoration + popstate (`routing`, unit `router`).
+
+**Gaps filled in PR 2:**
+- **Random play-again** — clicking the `/random` entry link → load + solve a second puzzle.
+  Was only `href`-checked, never followed (`random.spec`, `helpers/random.ts`).
+- **Dark-mode active shadow** — PR 1 shipped dark `--shadow-*` overrides with no test; added
+  a dark-mode mirror of the light shadow assertion (`shadow-theme.spec`).
+- **Completion popstate** — back/forward after solving stays on completion, the terminal
+  post-solve state (`routing.spec`).
+- **How-to-play menu link** — closes the menu and shows the help (welcome) screen via
+  `skipResolve` (`menu.spec`).
+- **Mid-game reload restore** — reloading keeps eliminations; the probe for the "phone
+  refresh restarts the puzzle" report (`restore.spec`). Passes → same-day restore works.
+
+**Tracked remaining gaps** (documented, not yet specced — low value / fragile / platform):
+- [ ] **Random completion links e2e** — assert random completion shows only Archive (no
+  "Show puzzle"). Already unit-covered (`completion-links`); e2e is low marginal value.
+- [ ] **Day-rollover mid-interaction (live gameplay e2e)** — unit-covered (`router`); the
+  visibility/focus variant was deferred here as fragile.
+- [ ] **/archive SSR-handoff analytics beacon e2e** — unit-covered (`router`); deferred as
+  fragile (document-unload beacon timing across the matrix).
+- [ ] **Analytics events fire** — `route_change` + archive beacon are unit-tested; per-event
+  e2e assertions (`puzzle_start`, `htp_opened`, …) are low value and flaky against the local
+  Analytics Engine binding.
+- [ ] **Dark-mode a11y (axe)** — axe runs light theme only; dark-theme contrast pass.
+- [ ] **iOS reload / storage eviction** — platform behaviour, not reproducible in Playwright.
+  Tracked as [#237](https://github.com/jevawin/clumeral-game/issues/237).
+
+**Stability note:** `random.spec` runs `mode: "serial"` and its readiness waits use a
+load-tolerant timeout; the WebKit-only `/api/dev/answer … access control checks` pageerror is
+allowlisted in `helpers/console.ts` (test-only endpoint, app already catches it). The full
+matrix is green in CI mode (retries:1); WebKit random tests can flake once under max local
+single-process concurrency and recover on retry, per the WebKit-flake policy below.
+
+---
+
 ## Goal
 
 A full automated Playwright regression suite covering every user-reachable flow in

--- a/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
+++ b/docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md
@@ -9,9 +9,18 @@
   → `staging` (branch `dev/post-redesign-stabilisation`). /random crash fix + restored entry
   link + theme-aware shadows. Full suite green (unit 120, e2e 208). Plan:
   [docs/superpowers/plans/2026-06-28-pr1-random-and-shadow-fixes.md](../plans/2026-06-28-pr1-random-and-shadow-fixes.md).
-- **PR 3 — CI smoke gate:** ⬜ next.
-- **PR 2 — QA coverage map → spec:** ⬜ pending.
-- **PR 4 — cleanup + doc refresh:** ⬜ pending.
+- **PR 3 — CI smoke gate:** ✅ done. PR [#234](https://github.com/jevawin/clumeral-game/pull/234)
+  → `staging` (branch `dev/ci-smoke-gate`). `.github/workflows/ci-smoke.yml` blocks merge to
+  `main` on a critical-path Playwright subset against the branch preview.
+- **PR 2 — QA coverage map → spec:** ✅ done (branch `dev/qa-coverage-map`). Built the
+  screen × flow coverage matrix (below), then filled the genuine gaps: random play-again
+  click→solve, dark-mode active shadow, completion-screen popstate, how-to-play menu link,
+  and a mid-game reload-restore probe. The reload probe passes (same-day restore works), so
+  the "phone refresh restarts the puzzle" report is captured as a platform-behaviour issue
+  ([#237](https://github.com/jevawin/clumeral-game/issues/237)), not a code bug. Coverage
+  matrix + remaining-gap checklist added to
+  [the QA regression design spec](2026-05-31-playwright-qa-regression-design.md).
+- **PR 4 — cleanup + doc refresh:** ⬜ next.
 
 The three-screen redesign (`cd206f9`, #226) and the `/migrate` hand-off (#231) shipped
 to production with a small set of regressions and left several docs stale. This program

--- a/e2e/helpers/console.ts
+++ b/e2e/helpers/console.ts
@@ -20,6 +20,12 @@ const ALLOW: RegExp[] = [
   /downloadable font: download failed/i,
   /ServiceWorker passed a promise to FetchEvent\.respondWith\(\) that resolved with non-Response/i,
   /An attempt was made to use an object that is not, or is no longer, usable/i,
+  // WebKit intermittently reports the same-origin /api/dev/answer fetch (the
+  // test-only solve helper) as blocked "due to access control checks" under
+  // parallel-matrix load / page teardown. The app already catches the rejection
+  // (app.ts _devFillAnswer try/catch); this is WebKit's separate page-level error
+  // event. Scoped to the dev endpoint so it can't mask a genuine same-origin error.
+  /\/api\/dev\/answer.*access control checks/i,
 ];
 
 export interface ConsoleGuard {

--- a/e2e/helpers/random.ts
+++ b/e2e/helpers/random.ts
@@ -15,17 +15,43 @@ import { expect } from "../fixtures.ts";
  * `startRandomPuzzle()`, after the token is set) removes `aria-busy` from
  * `[data-clue-list]`. Once that attribute is gone the token is guaranteed set.
  */
-export async function solveRandom(page: Page): Promise<void> {
-  await page.goto("/random");
+// /random fetches a fresh puzzle on every load; under full-matrix parallel load
+// the resource-constrained webkit projects can be slow to initialise, so the
+// readiness waits use a generous timeout (a real break still fails after it).
+const READY_TIMEOUT = 15_000;
+
+async function solveLoadedRandom(page: Page): Promise<void> {
   // Game is ready once clues have rendered (token is set by then).
   await expect(page.locator("[data-clue-list]")).not.toHaveAttribute(
     "aria-busy",
     "true",
+    { timeout: READY_TIMEOUT },
   );
-  await page.waitForFunction(() => typeof window._devFillAnswer === "function");
+  await page.waitForFunction(() => typeof window._devFillAnswer === "function", null, {
+    timeout: READY_TIMEOUT,
+  });
   await page.evaluate(() => window._devFillAnswer());
   // Wait for VISIBLE (not just enabled) — checkSubmit() unhides the wrap only
   // when all three boxes are size 1.
-  await expect(page.locator("[data-submit]")).toBeVisible();
+  await expect(page.locator("[data-submit]")).toBeVisible({ timeout: READY_TIMEOUT });
   await page.locator("[data-submit]").click();
+}
+
+export async function solveRandom(page: Page): Promise<void> {
+  await page.goto("/random");
+  await solveLoadedRandom(page);
+}
+
+/**
+ * From the random completion screen, click the sole `/random` entry link, then
+ * solve the freshly loaded puzzle. The link is a real `<a href="/random">` and
+ * /random boots without the router, so this is a full page navigation — wait for
+ * the URL before driving the new game.
+ */
+export async function playAnotherRandom(page: Page): Promise<void> {
+  await page
+    .locator("[data-completion-links] [data-completion-random-again]")
+    .click();
+  await page.waitForURL(/\/random$/);
+  await solveLoadedRandom(page);
 }

--- a/e2e/specs/menu.spec.ts
+++ b/e2e/specs/menu.spec.ts
@@ -3,6 +3,7 @@ import { MenuPage } from "../pages/menu.page.ts";
 import { FeedbackPage } from "../pages/feedback.page.ts";
 import { gotoPlayableGame } from "../helpers/game-setup.ts";
 import { expectActiveScreen } from "../helpers/screens.ts";
+import { solvePuzzle } from "../helpers/solve.ts";
 
 test.describe("header menu", () => {
   test("burger toggles the menu and flips aria-expanded; Esc closes it", async ({ page }) => {
@@ -18,17 +19,22 @@ test.describe("header menu", () => {
     await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
   });
 
-  test("how-to-play menu link closes the menu and shows the help (welcome) screen", async ({ page }) => {
+  test("how-to-play menu link reaches the help (welcome) screen even after solving", async ({ page }) => {
+    // Solve today first so a todayEntry exists — now /welcome resolves to /solved
+    // (route-resolver RTE-03). HTP navigates with skipResolve, which is the ONLY
+    // thing that lets a solved-today player still reach the welcome/help screen
+    // instead of being bounced back to completion. Solving first is what actually
+    // exercises that bypass.
     await gotoPlayableGame(page);
-    const menu = new MenuPage(page);
+    await solvePuzzle(page);
+    await expectActiveScreen(page, "completion");
 
+    const menu = new MenuPage(page);
     await menu.open();
     await expect(menu.htpBtn).toBeVisible();
     await menu.htpBtn.click();
 
-    // HTP navigates to /welcome (skipResolve), which holds the how-to-play content,
-    // and closes the burger. skipResolve is what lets a solved-today player still
-    // reach it instead of being bounced back to /solved.
+    // skipResolve bypassed the /welcome → /solved redirect; the burger closed.
     await expectActiveScreen(page, "welcome");
     await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
   });

--- a/e2e/specs/menu.spec.ts
+++ b/e2e/specs/menu.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../fixtures.ts";
 import { MenuPage } from "../pages/menu.page.ts";
 import { FeedbackPage } from "../pages/feedback.page.ts";
 import { gotoPlayableGame } from "../helpers/game-setup.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
 
 test.describe("header menu", () => {
   test("burger toggles the menu and flips aria-expanded; Esc closes it", async ({ page }) => {
@@ -14,6 +15,21 @@ test.describe("header menu", () => {
     await expect(menu.menu).toBeVisible();
 
     await page.keyboard.press("Escape");
+    await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("how-to-play menu link closes the menu and shows the help (welcome) screen", async ({ page }) => {
+    await gotoPlayableGame(page);
+    const menu = new MenuPage(page);
+
+    await menu.open();
+    await expect(menu.htpBtn).toBeVisible();
+    await menu.htpBtn.click();
+
+    // HTP navigates to /welcome (skipResolve), which holds the how-to-play content,
+    // and closes the burger. skipResolve is what lets a solved-today player still
+    // reach it instead of being bounced back to /solved.
+    await expectActiveScreen(page, "welcome");
     await expect(menu.menuBtn).toHaveAttribute("aria-expanded", "false");
   });
 

--- a/e2e/specs/random.spec.ts
+++ b/e2e/specs/random.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect } from "../fixtures.ts";
 import { expectActiveScreen } from "../helpers/screens.ts";
-import { solveRandom } from "../helpers/random.ts";
+import { solveRandom, playAnotherRandom } from "../helpers/random.ts";
+
+// Each /random test triggers a fresh `/api/puzzle/random` fetch (and the
+// play-another test triggers two). The local miniflare preview Worker serialises
+// these, so running the file's tests serially keeps the slower WebKit projects
+// from starving under full-matrix load — without it they flake on contention.
+test.describe.configure({ mode: "serial" });
 
 test.describe("/random", () => {
   test("solving a random puzzle lands on completion without error", async ({ page }) => {
@@ -22,5 +28,19 @@ test.describe("/random", () => {
     const again = page.locator("[data-completion-links] [data-completion-random-again]");
     await expect(again).toBeVisible();
     await expect(again).toHaveAttribute("href", "/random");
+  });
+
+  test("clicking 'play another random puzzle' loads and solves a second puzzle", async ({ page }) => {
+    await solveRandom(page);
+    await expectActiveScreen(page, "completion");
+
+    // Following the entry link must reach a fresh, solvable random puzzle —
+    // not bounce to welcome or throw the generic error (the regression class
+    // that orphaned this link in the redesign).
+    await playAnotherRandom(page);
+
+    await expect(page.locator("[data-feedback]")).not.toHaveText(/something went wrong/i);
+    await expectActiveScreen(page, "completion");
+    await expect(page.locator("[data-completion-heading]")).toHaveText(/solved/i);
   });
 });

--- a/e2e/specs/restore.spec.ts
+++ b/e2e/specs/restore.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "../fixtures.ts";
+import { seedHistory } from "../helpers/storage.ts";
+import { expectActiveScreen } from "../helpers/screens.ts";
+
+// Reloading mid-game must restore the in-progress board (D-06): saveActive() runs
+// on every digit change, and boot calls loadActive() to rebuild possibles. This is
+// the probe for the "phone refresh restarts the puzzle" report — if same-day
+// restore ever breaks, this fails. (The iOS overnight / storage-eviction case is a
+// platform behaviour tracked separately, not reproducible here.)
+test.describe("mid-game restore", () => {
+  test("reloading keeps eliminated digits (in-progress board survives a refresh)", async ({ page }) => {
+    // Past entry only → hasData, today unsolved (live game), first-play walkthrough off.
+    await seedHistory(page, [{ date: "2026-01-01", tries: 2 }]);
+
+    await page.goto("/play");
+    await expectActiveScreen(page, "game");
+    const box = page.locator('[data-digit="1"]');
+    await expect(box).toBeVisible();
+
+    // Eliminate 2, 3, 4 from box 1 via the real keypad — each click persists state.
+    await box.click();
+    await expect(page.locator("[data-keypad] [data-key]").first()).toBeVisible();
+    for (const d of [2, 3, 4]) {
+      await page.locator(`[data-key="${d}"]`).click();
+    }
+
+    const spans = page.locator('[data-digit="1"] .digit-box__grid span');
+    // Eliminated digits carry the `elim` class; survivors don't.
+    await expect(spans.nth(3)).toHaveClass(/elim/);
+    await expect(spans.nth(5)).not.toHaveClass(/elim/);
+
+    // The actual refresh.
+    await page.reload();
+
+    // Board must come back to the game screen with the same eliminations intact —
+    // not reset to a fresh puzzle or bounce to welcome.
+    await expectActiveScreen(page, "game");
+    const restored = page.locator('[data-digit="1"] .digit-box__grid span');
+    await expect(restored.nth(2)).toHaveClass(/elim/);
+    await expect(restored.nth(3)).toHaveClass(/elim/);
+    await expect(restored.nth(4)).toHaveClass(/elim/);
+    await expect(restored.nth(5)).not.toHaveClass(/elim/);
+  });
+});

--- a/e2e/specs/restore.spec.ts
+++ b/e2e/specs/restore.spec.ts
@@ -25,8 +25,11 @@ test.describe("mid-game restore", () => {
     }
 
     const spans = page.locator('[data-digit="1"] .digit-box__grid span');
-    // Eliminated digits carry the `elim` class; survivors don't.
+    // Eliminated digits carry the `elim` class; survivors don't. Assert the full
+    // before-state so it matches the post-reload check exactly.
+    await expect(spans.nth(2)).toHaveClass(/elim/);
     await expect(spans.nth(3)).toHaveClass(/elim/);
+    await expect(spans.nth(4)).toHaveClass(/elim/);
     await expect(spans.nth(5)).not.toHaveClass(/elim/);
 
     // The actual refresh.

--- a/e2e/specs/routing.spec.ts
+++ b/e2e/specs/routing.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../fixtures.ts";
 import { WelcomePage } from "../pages/welcome.page.ts";
 import { expectActiveScreen } from "../helpers/screens.ts";
 import { seedHistory } from "../helpers/storage.ts";
+import { solvePuzzle } from "../helpers/solve.ts";
 
 test.describe("routing", () => {
   test("history.scrollRestoration is set to 'manual' at boot", async ({ page }) => {
@@ -29,6 +30,33 @@ test.describe("routing", () => {
     await page.goForward();
     await expectActiveScreen(page, "game");
     expect(new URL(page.url()).pathname).toBe("/play");
+  });
+
+  test("back/forward after solving stays on completion (solved is terminal)", async ({ page }) => {
+    // Past entry only: today is unsolved, so /play opens the live game and the
+    // first-play walkthrough stays off.
+    await seedHistory(page, [{ date: "2026-01-01", tries: 2 }]);
+    const welcome = new WelcomePage(page);
+
+    await welcome.open();
+    await expectActiveScreen(page, "welcome");
+    await welcome.play();
+    await expectActiveScreen(page, "game");
+
+    // Solve today's puzzle — the app replaceRoute()s /play → /solved.
+    await solvePuzzle(page);
+    await expectActiveScreen(page, "completion");
+    expect(new URL(page.url()).pathname).toBe("/solved");
+
+    // Once today is solved, every route resolves to completion (route-resolver
+    // RTE-03). Back must NOT strand the player on a stale game board or welcome.
+    await page.goBack();
+    await expectActiveScreen(page, "completion");
+
+    // Forward returns to the canonical /solved URL, still completion.
+    await page.goForward();
+    await expectActiveScreen(page, "completion");
+    expect(new URL(page.url()).pathname).toBe("/solved");
   });
 
   // Deferred (fragile / lower value): the /archive SSR-handoff analytics beacon and

--- a/e2e/specs/shadow-theme.spec.ts
+++ b/e2e/specs/shadow-theme.spec.ts
@@ -1,9 +1,16 @@
 import { test, expect } from "../fixtures.ts";
+import type { Page } from "@playwright/test";
 
-// Force light mode so the Berry *light* value (#de1f46 = rgb(222,31,70)) applies.
-test.use({ colorScheme: "light" });
+// The active digit-box shadow is `color-mix(in srgb, var(--color-accent) 30%,
+// transparent)`, so its RGB channels equal the *selected accent's* RGB — and the
+// accent resolves to a different value per light/dark theme (colours.ts picks the
+// light or dark variant via isDark()). Both variants must drive the shadow, so we
+// assert the channels in each theme. The old bug used a hardcoded Lime shadow that
+// ignored both the accent and the theme.
 
-test("active digit-box shadow follows the selected accent colour", async ({ page }) => {
+// Select the Berry accent on a live /random board, activate box 0, and read back
+// the active-state shadow's RGB. color-mix serialises as `color(srgb r g b / .3)`.
+async function berryActiveShadow(page: Page): Promise<{ r: number; g: number; b: number }> {
   // /random loads the game screen with live digit boxes.
   await page.goto("/random");
   await expect(page.locator('[data-digit="0"]')).toBeVisible();
@@ -20,16 +27,34 @@ test("active digit-box shadow follows the selected accent colour", async ({ page
     .locator('[data-digit="0"]')
     .evaluate((el) => getComputedStyle(el).boxShadow);
 
-  // The active shadow now derives from --color-accent via color-mix, which
-  // Chromium serialises in the srgb colour space (e.g.
-  // "color(srgb 0.870588 0.121569 0.27451 / 0.3)") rather than as rgb(). Parse
-  // the channels back to 0–255 and assert they match Berry (222, 31, 70), and
-  // crucially NOT the old hardcoded Lime (10, 133, 10).
   const srgb = shadow.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/);
   expect(srgb, `expected an srgb color-mix shadow, got: ${shadow}`).not.toBeNull();
   const [r, g, b] = srgb!.slice(1, 4).map((c) => Math.round(parseFloat(c) * 255));
+  return { r, g, b };
+}
 
-  // Berry, not the hardcoded Lime.
-  expect({ r, g, b }).toEqual({ r: 222, g: 31, b: 70 });
-  expect({ r, g, b }).not.toEqual({ r: 10, g: 133, b: 10 });
+test.describe("light mode", () => {
+  // Force light mode so the Berry *light* value (#de1f46 = rgb(222,31,70)) applies.
+  test.use({ colorScheme: "light" });
+
+  test("active digit-box shadow follows the light accent", async ({ page }) => {
+    const rgb = await berryActiveShadow(page);
+    // Berry light, not the old hardcoded Lime.
+    expect(rgb).toEqual({ r: 222, g: 31, b: 70 });
+    expect(rgb).not.toEqual({ r: 10, g: 133, b: 10 });
+  });
+});
+
+test.describe("dark mode", () => {
+  // Force dark mode so the Berry *dark* value (#ea6c85 = rgb(234,108,133)) applies.
+  test.use({ colorScheme: "dark" });
+
+  test("active digit-box shadow follows the dark accent", async ({ page }) => {
+    const rgb = await berryActiveShadow(page);
+    // Berry dark, NOT the light variant (proves the shadow tracks the theme) and
+    // NOT the old hardcoded Lime.
+    expect(rgb).toEqual({ r: 234, g: 108, b: 133 });
+    expect(rgb).not.toEqual({ r: 222, g: 31, b: 70 });
+    expect(rgb).not.toEqual({ r: 10, g: 133, b: 10 });
+  });
 });


### PR DESCRIPTION
PR 2 of the post-redesign stabilisation program ([design](docs/superpowers/specs/2026-06-28-post-redesign-stabilisation-design.md)). Sequencing: PR 1 ✅ → PR 3 ✅ → **PR 2 (this)** → PR 4.

Built the screen × flow coverage map of the real test suite, then filled the genuine gaps it surfaced. **Tests + docs only — no production source changes.**

## Gaps filled (new / extended e2e specs)
- **Random play-again** — click the `/random` entry link → load + solve a second random puzzle. Was only `href`-checked, never followed; this is the entry-link regression class that started the whole program.
- **Dark-mode active shadow** — PR 1 shipped dark `--shadow-*` overrides with no test. Added a dark-mode mirror (Berry dark = rgb(234,108,133)); restructured into light + dark describes sharing a helper.
- **Completion popstate** — back/forward after solving stays on completion (solved is terminal, `app.ts:717-720`).
- **How-to-play menu link** — solves today first, then asserts HTP still reaches the welcome/help screen, genuinely exercising `skipResolve`.
- **Mid-game reload restore** (`restore.spec.ts`) — the probe for the "phone refresh restarts the puzzle" report. **It passes** → same-day restore works in code.

## The reload report
Static analysis + the new probe confirm same-day restore is fine (`saveActive` on every change, `loadActive` on boot, cold-load redirect only on a strictly-older date). The report is therefore the **overnight rollover** (by design) or **iOS storage eviction** (a Safari platform limit) — captured as #237 to investigate on a real device, not a code bug this PR can fix.

## Coverage map + remaining gaps
Added to the [QA regression design spec](docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md): the screen × flow map, what was filled, and a tracked checklist of low-value/fragile/platform gaps left (random completion-links e2e, day-rollover live e2e, archive beacon e2e, per-event analytics, dark-mode axe, #237).

## Stability
`random.spec` runs `mode: "serial"` with load-tolerant readiness timeouts; the WebKit-only `/api/dev/answer … access control checks` pageerror is allowlisted (test-only endpoint, app already catches it). 

## QA
Full matrix run against the production build (all 5 engines), CI mode: **unit 120, e2e 233 passed, 0 failed.** Review gates done (DA review → self-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)