### PR TITLE
Refresh stale references in DA/self-review checklists

### DIFF
--- a/docs/DA-REVIEW.md
+++ b/docs/DA-REVIEW.md
@@ -28,7 +28,7 @@ Devil's advocate review. Fresh-context subagent. Assume code is wrong until prov
 ## Theming & CSS
 
 - [ ] New colours use `light-dark(lightVal, darkVal)` with both values — **except** in SVG `fill`/`stroke` keyframes, where Lightning CSS rewrites `light-dark()` to two concatenated `var()`s (invalid paint → falls back to black). There, use paired custom props swapped per theme on `:root` / `html.dark`. See `@keyframes octo-colours` (#210).
-- [ ] Accent never hardcoded — uses `--acc` / `--acc-btn`
+- [ ] Accent never hardcoded — uses `--color-accent`
 - [ ] No fixed breakpoints — fluid via `max-width` + relative units
 - [ ] No `!important` unless overriding third-party
 - [ ] Works in both light and dark
@@ -42,7 +42,7 @@ Devil's advocate review. Fresh-context subagent. Assume code is wrong until prov
 ## Data & privacy
 
 - [ ] No PII collected/stored/transmitted
-- [ ] localStorage uses `dlng_` prefix (or existing `cw-htp-seen`)
+- [ ] localStorage uses `dlng_` prefix
 - [ ] No new external network requests (analytics, tracking, third-party scripts)
 
 ## Puzzle integrity

--- a/docs/SELF-REVIEW.md
+++ b/docs/SELF-REVIEW.md
@@ -14,9 +14,9 @@ Complements DA-REVIEW (architecture). This owns line-level details: stale values
 ## CSS accuracy
 
 - [ ] New custom props use `light-dark()` for theme-aware values — except SVG `fill`/`stroke` keyframes (use paired props on `:root`/`html.dark`; `light-dark()` breaks there after the Lightning CSS build pass — see #210)
-- [ ] Using existing vars (`--acc`, `--text`, `--muted` etc), not hardcoded hex
+- [ ] Using existing vars (`--color-accent`, `--color-text`, `--color-surface` etc), not hardcoded hex
 - [ ] Works in `color-scheme: light` and `dark`
-- [ ] `font-family` uses DM Sans (body) / Inconsolata (mono)
+- [ ] `font-family` uses Quicksand (body) / Inconsolata (mono)
 - [ ] No orphaned rules targeting removed/renamed elements
 
 ## HTML accuracy
@@ -34,14 +34,14 @@ Complements DA-REVIEW (architecture). This owns line-level details: stale values
 
 ## localStorage
 
-- [ ] Keys use `dlng_` prefix (or existing `cw-htp-seen`)
+- [ ] Keys use `dlng_` prefix
 - [ ] JSON shape matches existing readers — no breaking schema changes
 - [ ] `max 60` history limit still enforced
 
 ## Consistency
 
 - [ ] No duplicated constants across files — single source of truth
-- [ ] Same fix applied everywhere it's needed (app.ts AND style.css etc)
+- [ ] Same fix applied everywhere it's needed (app.ts AND tailwind.css etc)
 - [ ] No unused imports
 
 ## Worker / SW


### PR DESCRIPTION
Follow-up to PR #239. The DA-review and self-review checklists still referenced the same stale facts that #239 corrected elsewhere.

Fixes (all verified against current code):
- Fonts: `DM Sans` → `Quicksand` (`docs/SELF-REVIEW.md`).
- Main-app theme tokens: `--acc` / `--acc-btn` / `--text` / `--muted` → `--color-accent` / `--color-text` / `--color-surface` (both files). Note: `--acc` / `--muted` still exist, but only in the worker admin dashboards (`stats.ts` / `feedback.ts`), not the game UI these checklists cover.
- Drop the retired `cw-htp-seen` localStorage key (both files).
- `style.css` → `tailwind.css` (`docs/SELF-REVIEW.md`).

Docs-only, 2 files, 6 line edits. No code, no QA needed.