### PR TITLE
fix(sw): don't self-reload on first-ever load (unblocks CI smoke gate)

### DIFF
--- a/e2e/specs/sw-reload.spec.ts
+++ b/e2e/specs/sw-reload.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "../fixtures.ts";
+
+// Regression for the first-load self-reload race.
+//
+// The service worker posts SW_UPDATED from its `activate` handler on EVERY first
+// activation (install → skipWaiting → claim → notify). The app must reload only
+// on a GENUINE update — a page that already had a controller — not on this
+// install-time notification. Before the fix, a brand-new visit reloaded itself
+// the moment the SW claimed it: a spurious reload for real users, and one that
+// destroyed the execution context mid-test on slower CI runners (axe / screen
+// transition "navigation" failures in a11y.spec).
+test.describe("service worker", () => {
+  test("a first-ever load does not self-reload when the SW activates", async ({ page }) => {
+    // framenavigated on the main frame fires for the initial load and for any
+    // full reload, but NOT for SPA pushState/replaceState route changes — so the
+    // count isolates real document navigations.
+    let mainFrameNavigations = 0;
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame()) mainFrameNavigations++;
+    });
+
+    await page.goto("/welcome");
+
+    // Wait until the SW has claimed this page (controller set) — the exact point
+    // at which the install-time SW_UPDATED is delivered and the buggy reload fired.
+    await page.waitForFunction(() => !!navigator.serviceWorker.controller, null, {
+      timeout: 15_000,
+    });
+
+    // Give any (buggy) reload time to land after the claim, then assert none did.
+    await page.waitForTimeout(1_000);
+    expect(mainFrameNavigations).toBe(1);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -773,9 +773,17 @@ if ('serviceWorker' in navigator) {
   // updateViaCache: 'none' makes the browser bypass the HTTP cache when checking
   // /sw.js for updates, so a new deploy is picked up on the next navigation
   // instead of waiting up to 24h for the cached SW script to expire.
+  // Was this page already controlled by an SW when it loaded? On a first-ever
+  // visit it is not. The SW posts SW_UPDATED from its activate handler on *every*
+  // first activation (install → skipWaiting → claim → notify), so without this
+  // guard the first-ever load reloads itself the moment the SW claims it — a
+  // spurious reload for real users, and one that races axe/navigation in e2e
+  // (the freshly-claimed page navigates mid-test → "execution context destroyed").
+  // Only a genuine update — a page that already had a controller — should reload.
+  const hadController = !!navigator.serviceWorker.controller;
   navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' });
   navigator.serviceWorker.addEventListener('message', (e) => {
-    if (e.data?.type === 'SW_UPDATED') window.location.reload();
+    if (e.data?.type === 'SW_UPDATED' && hadController) window.location.reload();
   });
   // Force an update check whenever the page regains focus — covers PWAs and
   // long-lived tabs where navigation alone wouldn't trigger one.


### PR DESCRIPTION
## Problem
The CI smoke gate on the staging→main PR (#241) failed: two a11y specs (welcome + game) errored with `Execution context was destroyed, most likely because of a navigation`, on both the initial run and the retry.

## Root cause
The service worker posts `SW_UPDATED` from its `activate` handler on **every** first activation (install → `skipWaiting()` → `clients.claim()` → notify, [public/sw.js:25-30](public/sw.js#L25-L30)). The app reacted with `window.location.reload()` ([src/app.ts:778](src/app.ts#L778)). So a brand-new visit reloaded itself the instant the SW claimed the page.

- **Real users:** every first-ever visit does a spurious full reload.
- **CI:** on the slower runner that reload landed mid-`axe` run, destroying the execution context. Locally it passes only because a fast machine finishes the test before the SW activates.

## Fix
Guard the reload behind `hadController` — was the page already controlled by an SW at load? On a first visit it isn't, so the install-time notification no longer reloads. A genuine update (page already had a controller) still reloads as before.

## Verification
- New deterministic e2e regression (`e2e/specs/sw-reload.spec.ts`): a first-ever load must register exactly one main-frame navigation.
  - **Without** the fix: 2 navigations → fails (reproduces the bug locally).
  - **With** the fix: 1 navigation → passes.
- Typecheck clean; unit 120/120; CI-mode smoke 47/47 green.

## Note
The `ci-smoke` gate triggers only on PRs to `main`, so it won't run on this staging PR. Once this merges to `staging`, re-run / re-push #241 (staging→main) and the gate goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)