### PR TITLE
test(a11y): pin axe to light theme — deterministic smoke gate (unblocks #241)

### DIFF
--- a/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
+++ b/docs/superpowers/specs/2026-05-31-playwright-qa-regression-design.md
@@ -58,6 +58,10 @@ unit `sw-precache`), routing scrollRestoration + popstate (`routing`, unit `rout
   e2e assertions (`puzzle_start`, `htp_opened`, …) are low value and flaky against the local
   Analytics Engine binding.
 - [ ] **Dark-mode a11y (axe)** — axe runs light theme only; dark-theme contrast pass.
+  The a11y spec now pins `colorScheme: 'light'` so the gate is deterministic regardless
+  of the runner's OS preference (GitHub CI defaults to dark). Running it against dark mode
+  surfaced a real white-on-accent solid-button contrast failure (~2.9:1), tracked in
+  [#243](https://github.com/jevawin/clumeral-game/issues/243) — the dark-theme pass lives there.
 - [ ] **iOS reload / storage eviction** — platform behaviour, not reproducible in Playwright.
   Tracked as [#237](https://github.com/jevawin/clumeral-game/issues/237).
 

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -20,6 +20,13 @@ async function seriousViolations(page: import("@playwright/test").Page) {
 // flaky redundant axe runs that overload the single preview server.
 const A11Y_PROJECTS = ["chromium-desktop", "mobile-chromium"];
 
+// This axe pass is intentionally light-theme-only (see the QA regression design
+// doc). Pin colorScheme so the gate is deterministic regardless of the runner's
+// OS preference — GitHub's CI runner defaults to prefers-color-scheme: dark, which
+// would otherwise run these checks against dark mode and trip a KNOWN, separately
+// tracked dark-mode contrast bug (white-on-accent solid buttons, ~2.9:1): #243.
+// Dark-mode a11y remains a tracked gap, not part of this light-theme gate.
+test.use({ colorScheme: "light" });
 test.describe("accessibility (axe — serious/critical)", () => {
   test.beforeEach(({}, testInfo) => {
     test.skip(


### PR DESCRIPTION
## Problem
The CI smoke gate on #241 (staging→main) failed two a11y specs with `color-contrast (serious)` after the SW-reload fix let axe run to completion. Root cause: GitHub's CI runner defaults to `prefers-color-scheme: dark`, so the axe pass ran against **dark mode** — but it's designed light-theme-only and never pinned `colorScheme`. Dark mode exposed a pre-existing contrast bug: `.btn-solid` = white text on the accent background ≈ **2.93:1** (needs 4.5:1).

## Fix
Pin `colorScheme: 'light'` on the a11y describe so the gate is deterministic regardless of the runner's OS preference and matches its documented scope ("axe runs light theme only").

## The real bug is tracked, not lost
The dark-mode white-on-accent contrast failure is genuine but **pre-existing** (the accent tokens in `src/colours.ts` aren't touched by the #241 batch) and was already a documented gap. Filed as **#243** with the measured evidence and fix direction (needs colour/design decisions + review gates).

## Verification
- With the project forced to dark, the a11y specs now **pass** (the pin overrides) — proving the dark-defaulting CI runner will pass.
- Full CI-mode smoke: **47/47**.

## After merge
Merge to `staging`, then re-run #241's gate (it only triggers on PRs to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)