### PR TITLE
fix(a11y): AA-safe accent text for clue tags + emphasis (real fix for #241 gate)

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -22,6 +22,10 @@ Five tokens defined in `@theme` block. Dark mode overrides in `@layer theme` und
 
 Tailwind generates utility classes from these: `bg-bg`, `text-text`, `bg-accent`, `bg-surface`, `border-border`. The legacy `muted` token was removed in v1.1 (CLR-01) — secondary copy now uses `text-text`. Use `text-text/60` only for non-essential placeholder/decorative variants where pure text is unreadable.
 
+### Derived: `accent-strong` (AA-safe accent text)
+
+`--color-accent-strong` = `color-mix(in srgb, var(--color-accent) 82%, var(--color-text))`. The raw accent on light backgrounds sits at ~4.3:1 on the clue-tag tint (`bg-accent/5`) and ~4.6:1 on the page bg — at or below WCAG AA 4.5:1. Mixing 18% toward `text` darkens it in light mode and lightens it in dark mode, lifting all four accent themes to ~5.3:1+ (light) / ~7.5:1 (dark). Both source vars are live, so it re-resolves per accent and per theme — no `dark:` variant needed. Use `text-accent-strong` for accent-coloured **text**; keep raw `--color-accent` (`text-accent`, `border-accent`, `bg-accent`) for icons, borders, and fills.
+
 ## Typography
 
 - Body / headings: **Quicksand** 400/600/700 (Google Fonts), fallback `system-ui` — `--font-sans`

--- a/src/app.ts
+++ b/src/app.ts
@@ -258,7 +258,7 @@ function renderClues(clues: ClueData[]): void {
     clueEl.setAttribute("role", "listitem");
     clueEl.innerHTML = `
       <div class="flex flex-col gap-2">
-        <button class="flex items-center justify-between gap-1 px-1 h-[1.375rem] rounded border border-accent bg-accent/5 text-accent font-mono text-base font-bold uppercase tracking-wide" type="button" data-clue-tag aria-label="${tag} — tap for definition">
+        <button class="flex items-center justify-between gap-1 px-1 h-[1.375rem] rounded border border-accent bg-accent/5 text-accent-strong font-mono text-base font-bold uppercase tracking-wide" type="button" data-clue-tag aria-label="${tag} — tap for definition">
           <span>${tag}</span>
           <svg width="14" height="14" class="stroke-[2.5]" aria-hidden="true"><use href="/sprites.svg#icon-info"/></svg>
         </button>
@@ -272,7 +272,7 @@ function renderClues(clues: ClueData[]): void {
 
     const l1El = clueEl.querySelector("[data-clue-line1]");
     const leadHtml = leadText.replace(/\b(all three|mean|sum|range|product|difference|first|second|third)\b/gi, '<span class="font-bold">$1</span>');
-    if (l1El) l1El.innerHTML = `${leadHtml} <span class="font-bold text-accent whitespace-nowrap">${emphHtml}</span>`;
+    if (l1El) l1El.innerHTML = `${leadHtml} <span class="font-bold text-accent-strong whitespace-nowrap">${emphHtml}</span>`;
     dom.clueList.appendChild(clueEl);
   }
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -39,6 +39,15 @@
   --color-surface: #FFFFFF;
   --color-border:  rgba(38, 38, 36, 0.12);
 
+  /* AA-safe accent for small text. The raw accent on light backgrounds sits at
+     ~4.3:1 on the clue-tag tint and ~4.6:1 on the page bg — at or below the 4.5:1
+     WCAG AA bar. Mixing 18% toward --color-text darkens it in light mode and
+     lightens it in dark mode, lifting all four themes to ~5.3:1+ while staying
+     visibly the accent. Both source vars are live, so it re-resolves per accent
+     and per theme — no dark: override needed. Use for accent-coloured TEXT;
+     keep raw --color-accent for icons, borders, and fills. */
+  --color-accent-strong: color-mix(in srgb, var(--color-accent) 82%, var(--color-text));
+
   /* Offset shadows derive from theme tokens so they follow dark mode and the
      selected accent. --color-text / --color-accent are live custom properties
      (accent is set per-swatch in colours.ts), so color-mix re-resolves on theme

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -40,7 +40,7 @@ export const START_DELAY_MS = 5000;
 // While talking, the brand text drops to clue size (16px), bold, left-aligned, in
 // the clue font (Quicksand) and theme accent colour — not the Comfortaa wordmark.
 // The action lead (boldPrefix) is rendered bold + italic to stand apart.
-const WALKTHROUGH_CLASS = 'text-base font-bold text-accent font-[Quicksand] text-left leading-tight';
+const WALKTHROUGH_CLASS = 'text-base font-bold text-accent-strong font-[Quicksand] text-left leading-tight';
 
 // True iff `event` is the gate this step is waiting on.
 export function gateMatches(step: Step, event: GateEvent): boolean {

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -43,7 +43,7 @@ function htpSteps(): string {
         <p class="text-base text-text mb-2">1. Read the clues — tap <svg class="inline align-[-2px] text-accent" width="14" height="14" aria-hidden="true"><use href="/sprites.svg#icon-info"/></svg> for an explanation</p>
         <div class="grid [grid-template-columns:max-content_1fr] gap-x-4 items-center">
           <div class="flex flex-col gap-2">
-            <span class="flex items-center justify-between gap-1 px-1 h-[1.375rem] rounded border border-accent bg-accent/5 text-accent font-mono text-base font-bold uppercase tracking-wide">
+            <span class="flex items-center justify-between gap-1 px-1 h-[1.375rem] rounded border border-accent bg-accent/5 text-accent-strong font-mono text-base font-bold uppercase tracking-wide">
               <span>PRIME</span>
               <svg width="14" height="14" class="stroke-[2.5]" aria-hidden="true"><use href="/sprites.svg#icon-info"/></svg>
             </span>
@@ -53,7 +53,7 @@ function htpSteps(): string {
               <span class="w-[1.375rem] h-[1.375rem] rounded-[1px] border border-accent bg-accent/5"></span>
             </div>
           </div>
-          <div class="text-lg text-text font-[Quicksand]">The <span class="font-bold">first</span> digit is <span class="font-bold text-accent whitespace-nowrap">a prime number</span></div>
+          <div class="text-lg text-text font-[Quicksand]">The <span class="font-bold">first</span> digit is <span class="font-bold text-accent-strong whitespace-nowrap">a prime number</span></div>
         </div>
       </div>
 


### PR DESCRIPTION
## The real root cause of the #241 gate failure
After the SW-reload fix let axe run to completion, the CI smoke gate caught a genuine, **pre-existing** WCAG AA contrast failure (captured the exact axe data via a throwaway diagnostic run):

- Clue-tag labels — `text-accent` (`#0a850a`) on the `bg-accent/5` tint (`#eef4ee`) = **4.3:1** in light mode, **across all four accent themes** (Lime/Berry/Blue/Violet). Below the 4.5:1 AA bar.
- Numeric-emphasis + walkthrough accent text = ~4.6:1 — passing but on the edge.

It's right on the threshold, so it failed deterministically on the slower CI runner and only *flaked* locally. (My earlier dark-mode theory was wrong — CI renders light mode; this is the actual cause.)

## Fix
Add a derived token `--color-accent-strong` = `color-mix(in srgb, var(--color-accent) 82%, var(--color-text))`. Mixing 18% toward `text` darkens the accent in light mode and lightens it in dark mode, and re-resolves per accent theme automatically (both source vars are live — same pattern as the existing `--shadow-*` tokens, so no `dark:` override). Switch accent-coloured **text** (clue tags, numeric emphasis, welcome htp example, walkthrough) to `text-accent-strong`; raw `--color-accent` stays for icons, borders, and fills.

Result: all four themes clear **~5.3:1+** (light) / **~7.5:1** (dark).

## Review gates
- **DA review** (fresh-context subagent): APPROVE WITH NITS — recomputed the contrast math and confirmed per-theme/per-mode re-resolution; only nit was the design-system doc, now updated.
- **Self-review**: passed. Note: used `color-mix(var(--color-accent)…)` rather than `light-dark()` because the accent is set at runtime by the swatch picker — a static light/dark pair can't capture it.

## Verification
- axe 30/30 across chromium desktop + mobile, repeated 3× — no flake.
- Forced-dark a11y 5/5; full CI-mode smoke 47/47; typecheck clean.

## After merge
Merge to `staging`, then re-run #241's gate — with the SW fix (#242), the light pin (#244), and this, it should finally go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)